### PR TITLE
Fix garbled rendering after terminal resize (fullscreen)

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -56,6 +56,17 @@ pub fn run(stream: UnixStream) -> std::io::Result<ClientExit> {
                     Ok(_) => {
                         if let Ok(msg) = serde_json::from_str::<FrameMsg>(line.trim()) {
                             *flags.lock().unwrap() = msg.flags;
+                            if msg.clear {
+                                // Re-baseline (attach / resize): erase every cell and
+                                // delete all image placements *and* their data. A cell
+                                // repaint alone can never remove an image — terminals
+                                // composite graphics over text — and after a resize the
+                                // emulator's screen/image state can diverge from our
+                                // incremental model, leaving orphaned icons on screen.
+                                let _ = out.write_all(b"\x1b[0m\x1b[2J\x1b_Ga=d,d=A\x1b\\");
+                                transmitted.clear();
+                                active.clear();
+                            }
                             let ansi = frame_to_ansi(&msg.changes, &caps);
                             let _ = out.write_all(ansi.as_bytes());
                             if caps.kitty_graphics {
@@ -311,7 +322,10 @@ fn reconcile_images(
     // (image_id, x, y, cols, rows).
     let mut now: std::collections::HashMap<u32, (u64, i32, i32, u16, u16)> = std::collections::HashMap::new();
     for p in &msg.images {
-        if p.visible {
+        // A negative origin can't be addressed: CUP parameters are 1-based, and
+        // a 0/negative parameter aborts the escape, dropping the image at the
+        // current cursor position — i.e. painted at an arbitrary screen spot.
+        if p.visible && p.rect.x >= 0 && p.rect.y >= 0 {
             now.insert(place_key(p.rect.x, p.rect.y), (p.id, p.rect.x, p.rect.y, p.cols, p.rows));
         }
     }
@@ -419,6 +433,69 @@ fn send(stream: &mut UnixStream, msg: &ClientMsg) -> std::io::Result<()> {
     let mut buf = serde_json::to_vec(msg).map_err(std::io::Error::other)?;
     buf.push(b'\n');
     stream.write_all(&buf)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::geometry::Rect;
+    use crate::protocol::ImagePlacement;
+
+    fn frame_with(images: Vec<ImagePlacement>) -> FrameMsg {
+        FrameMsg {
+            changes: Vec::new(),
+            cursor: None,
+            flags: Flags::default(),
+            images,
+            image_data: Vec::new(),
+            clear: false,
+        }
+    }
+
+    #[test]
+    fn places_visible_placement_with_cup_and_place_ops() {
+        let msg = frame_with(vec![ImagePlacement {
+            id: 7,
+            rect: Rect::new(2, 3, 4, 2),
+            cols: 4,
+            rows: 2,
+            visible: true,
+        }]);
+        let mut transmitted = std::collections::HashSet::new();
+        let mut active = std::collections::HashMap::new();
+        let g = reconcile_images(&msg, &mut transmitted, &mut active);
+        assert!(g.contains("\x1b[4;3H"), "CUP to 1-based (row 4, col 3): {g:?}");
+        assert!(g.contains("a=p"), "place op emitted: {g:?}");
+        assert_eq!(active.len(), 1);
+    }
+
+    #[test]
+    fn skips_placement_with_negative_origin() {
+        // A CUP with a 0/negative parameter aborts the escape and the image
+        // would land at the current cursor position — never emit one.
+        let msg = frame_with(vec![ImagePlacement {
+            id: 7,
+            rect: Rect::new(-3, 5, 4, 2),
+            cols: 4,
+            rows: 2,
+            visible: true,
+        }]);
+        let mut transmitted = std::collections::HashSet::new();
+        let mut active = std::collections::HashMap::new();
+        let g = reconcile_images(&msg, &mut transmitted, &mut active);
+        assert!(!g.contains("a=p"), "no place op for an unaddressable rect: {g:?}");
+        assert!(active.is_empty());
+    }
+
+    #[test]
+    fn deletes_placement_that_disappeared() {
+        let mut transmitted = std::collections::HashSet::new();
+        let mut active = std::collections::HashMap::new();
+        active.insert(place_key(2, 3), (7u64, 2, 3, 4u16, 2u16));
+        let g = reconcile_images(&frame_with(Vec::new()), &mut transmitted, &mut active);
+        assert!(g.contains("a=d,d=i,i=7"), "stale placement deleted: {g:?}");
+        assert!(active.is_empty());
+    }
 }
 
 /// Encode a key into the bytes forwarded to the focused PTY app.

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -205,6 +205,11 @@ fn serve_client(
     // Image ids whose bytes this client has already received (reset per attach,
     // mirroring the full cell-repaint above).
     let mut sent_image_ids: std::collections::HashSet<u64> = std::collections::HashSet::new();
+    // Ask the client to wipe the terminal (cells + images) before the next
+    // frame. Set on attach and on every resize: the emulator may have reflowed
+    // cells and kept image placements the incremental diff/delete stream no
+    // longer knows about, so only a full re-baseline is trustworthy.
+    let mut clear_pending = true;
 
     loop {
         // Apply all pending input.
@@ -213,6 +218,9 @@ fn serve_client(
                 Ok(ClientMsg::Resize { w, h }) => {
                     comp.resize(w, h);
                     core.apply(ClientMsg::Resize { w, h });
+                    clear_pending = true;
+                    // The client's wipe frees transmitted image data; re-send it.
+                    sent_image_ids.clear();
                 }
                 Ok(msg) => core.apply(msg),
                 Err(mpsc::TryRecvError::Empty) => break,
@@ -270,6 +278,7 @@ fn serve_client(
             flags,
             images: frame.images.clone(),
             image_data,
+            clear: clear_pending,
         })
             .unwrap_or_default();
         buf.push(b'\n');
@@ -277,6 +286,7 @@ fn serve_client(
             return; // client gone
         }
         comp.commit();
+        clear_pending = false;
 
         if core.quit_requested() {
             return; // detach (flag already delivered)

--- a/src/desktop.rs
+++ b/src/desktop.rs
@@ -209,10 +209,17 @@ impl<F: FsOps> DesktopIcons<F> {
     /// The screen rect of an icon's tile. Columns fill from the **top-right**
     /// (like macOS): logical column 0 is the rightmost, flush to the right edge
     /// (minus a one-cell margin).
+    ///
+    /// The cell is clamped into the current grid: saved (or previously assigned)
+    /// cells can lie outside it after the screen shrinks — including transient
+    /// mid-animation sizes during a fullscreen toggle — and an unclamped column
+    /// would put the tile at negative x, over the windows at the left edge.
     pub fn tile_rect(&self, cell: (u16, u16)) -> crate::geometry::Rect {
         const MARGIN: i32 = 1;
-        let x = self.width - MARGIN - (cell.0 as i32 + 1) * ICON_W;
-        crate::geometry::Rect::new(x, GRID_TOP + cell.1 as i32 * ICON_H, ICON_W, ICON_H)
+        let col = (cell.0 as i32).min(self.cols.max(1) as i32 - 1);
+        let row = (cell.1 as i32).min(self.rows.max(1) as i32 - 1);
+        let x = self.width - MARGIN - (col + 1) * ICON_W;
+        crate::geometry::Rect::new(x, GRID_TOP + row * ICON_H, ICON_W, ICON_H)
     }
 
     /// The screen rect of the icon *image* within a tile — centered horizontally,

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -23,6 +23,13 @@ pub struct FrameMsg {
     /// PNG bytes for images not yet sent to this client (base64), sent once.
     #[serde(default)]
     pub image_data: Vec<ImageBlob>,
+    /// The screen was re-baselined (attach or resize): before applying this
+    /// frame the client must erase all cells, delete every image placement
+    /// (and its transmitted data), and forget its cached image state. A resize
+    /// invalidates everything incremental — the emulator may have reflowed
+    /// cells and kept placements the diff/delete stream no longer knows about.
+    #[serde(default)]
+    pub clear: bool,
 }
 
 /// A request to place image `id` at `rect` (screen cells). `visible=false` tells

--- a/src/session.rs
+++ b/src/session.rs
@@ -2585,6 +2585,7 @@ echo 'Update failed — tuiui not reloaded.'; exec \"$SHELL\"",
         if !menu_rects.is_empty() {
             images.retain(|p| menu_rects.iter().all(|o| o.intersect(p.rect).is_none()));
         }
+        sanitize_images(&mut images, self.w, self.h);
 
         Frame { layers, cursor: Some(self.cursor), images }
     }
@@ -2691,6 +2692,7 @@ echo 'Update failed — tuiui not reloaded.'; exec \"$SHELL\"",
             .map(|l| crate::geometry::Rect::new(l.origin.x, l.origin.y, l.buf.width(), l.buf.height()))
             .collect();
         images.retain(|p| overlay_rects.iter().all(|o| o.intersect(p.rect).is_none()));
+        sanitize_images(&mut images, self.w, self.h);
 
         Frame { layers, cursor: Some(self.cursor), images }
     }
@@ -2822,6 +2824,16 @@ fn near_edge(p: Point, work: Rect, threshold: i32) -> bool {
         || work.bottom() - p.y < threshold
 }
 
+/// Drop image placements the client can't address on a `w`×`h` screen: a rect
+/// with a negative origin would emit a CUP with a 0/negative parameter, which
+/// terminals reject — the image would then be placed at whatever cell the
+/// cursor happens to be on (an icon painted over an arbitrary spot, typically
+/// seen right after a resize). Origins past the right/bottom edge are dropped
+/// too; they would be entirely invisible anyway.
+fn sanitize_images(images: &mut Vec<crate::protocol::ImagePlacement>, w: i32, h: i32) {
+    images.retain(|p| p.rect.x >= 0 && p.rect.y >= 0 && p.rect.x < w && p.rect.y < h);
+}
+
 /// Check the upstream repository for a newer commit than this build.
 ///
 /// Uses `curl` against the GitHub API with a hard timeout so the call can never
@@ -2852,5 +2864,35 @@ fn check_for_updates() -> String {
             }
         }
         None => "Couldn't check (offline?)".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn placement(x: i32, y: i32) -> crate::protocol::ImagePlacement {
+        crate::protocol::ImagePlacement {
+            id: 1,
+            rect: Rect::new(x, y, 4, 3),
+            cols: 4,
+            rows: 3,
+            visible: true,
+        }
+    }
+
+    #[test]
+    fn sanitize_drops_unaddressable_and_offscreen_placements() {
+        let mut images = vec![
+            placement(0, 0),     // kept: top-left corner
+            placement(-2, 5),    // dropped: negative x (CUP param would be ≤ 0)
+            placement(5, -1),    // dropped: negative y
+            placement(100, 5),   // dropped: origin past the right edge
+            placement(5, 30),    // dropped: origin past the bottom edge
+            placement(99, 29),   // kept: last addressable cell
+        ];
+        sanitize_images(&mut images, 100, 30);
+        let origins: Vec<(i32, i32)> = images.iter().map(|p| (p.rect.x, p.rect.y)).collect();
+        assert_eq!(origins, vec![(0, 0), (99, 29)]);
     }
 }

--- a/tests/desktop_tests.rs
+++ b/tests/desktop_tests.rs
@@ -139,3 +139,33 @@ fn drag_snaps_to_target_cell_and_reports_position() {
     assert_eq!(dt.position_of(&key), Some((2, 1)));
     let _ = fs::remove_dir_all(&d);
 }
+
+#[test]
+fn shrinking_layout_keeps_tiles_and_placements_on_screen() {
+    // An icon saved deep into a wide grid must not land at negative x after the
+    // screen shrinks (e.g. a transient size mid fullscreen-animation) — that
+    // would draw it over the windows at the left edge, and its image placement
+    // would be unaddressable by the client.
+    let d = tmp("shrink");
+    fs::write(d.join("a"), b"").unwrap();
+    let mut pos = BTreeMap::new();
+    pos.insert(d.join("a").to_string_lossy().to_string(), (5u16, 3u16));
+    let mut dt = DesktopIcons::new(d.clone());
+    dt.layout(200, 60); // wide grid: column 5 is valid
+    dt.reload(&[], &pos);
+    assert_eq!(dt.icons()[0].cell, (5, 3));
+    assert!(dt.tile_rect((5, 3)).x >= 0);
+
+    dt.layout(40, 12); // narrow grid: column 5 would be x = 40-1-6*14 < 0 unclamped
+    let r = dt.tile_rect((5, 3));
+    assert!(r.x >= 0, "tile clamped into the grid; got x={}", r.x);
+    assert!(r.y >= 1, "tile clamped below the menubar; got y={}", r.y);
+
+    let mut role_icons = std::collections::HashMap::new();
+    role_icons.insert(dt.icons()[0].role, 42u64);
+    let placements = dt.icon_placements(&role_icons, |_| true);
+    assert_eq!(placements.len(), 1);
+    assert!(placements[0].rect.x >= 0 && placements[0].rect.y >= 0,
+        "placement stays addressable: {:?}", placements[0].rect);
+    let _ = fs::remove_dir_all(&d);
+}

--- a/tests/protocol_tests.rs
+++ b/tests/protocol_tests.rs
@@ -26,12 +26,23 @@ fn frame_msg_roundtrips_json() {
         flags: Flags { launcher_open: true, ..Default::default() },
         images: Vec::new(),
         image_data: Vec::new(),
+        clear: true,
     };
     let s = serde_json::to_string(&f).unwrap();
     let back: FrameMsg = serde_json::from_str(&s).unwrap();
     assert_eq!(back.changes.len(), 1);
     assert_eq!(back.changes[0].cell.ch, 'A');
     assert!(back.flags.launcher_open);
+    assert!(back.clear);
+}
+
+#[test]
+fn frame_msg_clear_defaults_off_for_older_daemons() {
+    // A frame from a daemon that predates `clear` must still parse, with the
+    // wipe defaulted off (no spurious screen clears on version skew).
+    let s = r#"{"changes":[],"cursor":null,"flags":{}}"#;
+    let f: FrameMsg = serde_json::from_str(s).unwrap();
+    assert!(!f.clear);
 }
 
 #[test]


### PR DESCRIPTION
## Problem

Resizing the terminal (e.g. toggling macOS fullscreen) left the desktop garbled: orphaned desktop-icon images painted over the power menu and window titles, icon labels at stale positions, two icon layouts visually superimposed.

## Root cause

On resize the daemon already forces a full **cell** repaint (`Compositor::resize` resets both buffers, so the next diff re-emits every cell). But nothing re-baselines the **Kitty graphics plane**:

- Terminals composite images **over** text, so no amount of cell repainting can erase a stale image placement.
- The client tracks placements incrementally (`active`/`transmitted` in `reconcile_images`) and only deletes placements it knows about. A fullscreen animation delivers a burst of intermediate sizes with frames for stale geometry still in flight; the emulator's image/screen state diverges from the client's incremental model, and the leftovers stick forever.

Two adjacent sharp edges made it worse:

1. `reconcile_images` emitted cursor-position escapes with raw, possibly non-positive coordinates. CUP parameters are 1-based; a 0/negative parameter aborts the escape, and the following place op drops the image at whatever cell the cursor happens to be on — an icon painted at an arbitrary screen spot.
2. Desktop icons keep grid cells assigned/saved under the old geometry; after a shrink (including transient mid-animation sizes) an unclamped column puts the tile at negative x, over the windows at the left edge.

## Fix

- **protocol**: add a `clear` flag to `FrameMsg` (`serde(default)`, so version skew is harmless in both directions).
- **daemon**: set it on attach and on every `Resize`; also reset the sent-image-id set so image data is retransmitted after the wipe.
- **client**: on a `clear` frame, erase all cells (`SGR reset + ED 2`), delete every image placement and its data (`a=d,d=A`), and drop the `transmitted`/`active` caches before applying the frame. The frame carrying the flag already contains the full grid diff, so the screen rebuilds from a known-clean baseline.
- **client + session**: never emit a placement with a negative origin (client-side guard in `reconcile_images`, daemon-side `sanitize_images` in both frame-build paths).
- **desktop**: clamp icon tiles into the current grid in `tile_rect` so cells saved under a larger screen can't produce off-grid tiles after a shrink.

## Tests

- `client`: new unit tests for `reconcile_images` — place/CUP emission, negative-origin skip, stale-placement delete.
- `session`: unit test for `sanitize_images`.
- `protocol`: round-trip with `clear`, plus old-daemon frames (no `clear` field) defaulting it off.
- `desktop`: regression test that a shrink keeps tiles and placements on screen.

All 277 tests pass; clippy clean apart from one pre-existing warning in `gpm.rs`.

https://claude.ai/code/session_01PHhvCiUaRhbWNQK9qJYtYz

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHhvCiUaRhbWNQK9qJYtYz)_