### PR TITLE
sync: main → dev (release workflow)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,13 @@ name: Release
 on:
   push:
     tags: ["v*"]
-  workflow_dispatch: {}
+  # Manual runs create the tag + release themselves (used by environments that
+  # can build PRs but cannot push tags). The version must match Cargo.toml.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to create (e.g. v0.2.0)"
+        required: true
 
 permissions:
   contents: write
@@ -39,7 +45,11 @@ jobs:
         run: tar -C target/${{ matrix.target }}/release -czf tuiui-${{ matrix.target }}.tar.gz tuiui
 
       - name: Attach to release
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
         uses: softprops/action-gh-release@v2
         with:
+          # On dispatch this creates the tag (at the run's commit) and the
+          # release; on a tag push it attaches to the existing tag's release.
+          tag_name: ${{ github.event.inputs.tag || github.ref_name }}
+          body: "See CHANGELOG.md for the full release notes."
           files: tuiui-${{ matrix.target }}.tar.gz


### PR DESCRIPTION
Keep dev in sync with main (dispatchable release workflow) so the dev channel starts from the v0.2.0 state.

https://claude.ai/code/session_012HBi5A2gpLS8WzurJfqUG3

---
_Generated by [Claude Code](https://claude.ai/code/session_012HBi5A2gpLS8WzurJfqUG3)_