### PR TITLE
hotfix: Debian-compatible installer + release builds (glibc/wget/arm64)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,12 @@ jobs:
           # on the heavily-backlogged macos-13 (Intel) runner.
           - { os: macos-14, target: aarch64-apple-darwin }
           - { os: macos-14, target: x86_64-apple-darwin }
-          - { os: ubuntu-latest, target: x86_64-unknown-linux-gnu }
+          # Linux builds run on 22.04 ON PURPOSE: its glibc 2.35 keeps the
+          # binaries runnable on Debian 12 (glibc 2.36) and Ubuntu 22.04+ —
+          # ubuntu-latest (24.04, glibc 2.39) produced binaries that died on
+          # Debian with "GLIBC_2.39 not found".
+          - { os: ubuntu-22.04, target: x86_64-unknown-linux-gnu }
+          - { os: ubuntu-22.04-arm, target: aarch64-unknown-linux-gnu }
     steps:
       - uses: actions/checkout@v4
 

--- a/install.sh
+++ b/install.sh
@@ -9,12 +9,21 @@ set -eu
 REPO="jaylfc/tuiui"
 BIN_DIR="${TUIUI_BIN_DIR:-$HOME/.local/bin}"
 
+# Stock Debian often has wget but not curl; accept either.
+fetch() {
+  if command -v curl >/dev/null 2>&1; then curl -fsSL "$1"
+  elif command -v wget >/dev/null 2>&1; then wget -qO- "$1"
+  else echo "tuiui: need curl or wget to download" >&2; return 1
+  fi
+}
+
 os="$(uname -s)"
 arch="$(uname -m)"
 case "$os/$arch" in
   Darwin/arm64)        target="aarch64-apple-darwin" ;;
   Darwin/x86_64)       target="x86_64-apple-darwin" ;;
   Linux/x86_64)        target="x86_64-unknown-linux-gnu" ;;
+  Linux/aarch64)       target="aarch64-unknown-linux-gnu" ;;
   *)
     echo "tuiui: no prebuilt binary for $os/$arch."
     echo "Install with Rust instead:  cargo install --git https://github.com/$REPO"
@@ -22,7 +31,7 @@ case "$os/$arch" in
 esac
 
 echo "tuiui: finding latest release…"
-tag="$(curl -fsSL "https://api.github.com/repos/$REPO/releases/latest" \
+tag="$(fetch "https://api.github.com/repos/$REPO/releases/latest" \
         | grep '"tag_name"' | head -1 | cut -d'"' -f4)"
 if [ -z "${tag:-}" ]; then
   echo "tuiui: no published release yet."
@@ -33,7 +42,7 @@ fi
 url="https://github.com/$REPO/releases/download/$tag/tuiui-$target.tar.gz"
 echo "tuiui: downloading $tag ($target)…"
 mkdir -p "$BIN_DIR"
-if ! curl -fsSL "$url" | tar -xz -C "$BIN_DIR" 2>/dev/null || [ ! -f "$BIN_DIR/tuiui" ]; then
+if ! fetch "$url" | tar -xz -C "$BIN_DIR" 2>/dev/null || [ ! -f "$BIN_DIR/tuiui" ]; then
   echo "tuiui: no prebuilt binary for $target in $tag."
   echo "Install with Rust instead:  cargo install --git https://github.com/$REPO"
   exit 1


### PR DESCRIPTION
Hotfix promotion of ONLY the installer + release workflow (no tuiui source changes — the binary stays identical to v0.2.0), so the Debian Add Remote failure is unblocked without promoting dev features:

- `install.sh`: curl **or wget** (stock Debian often lacks curl); Linux **aarch64** target mapping.
- `release.yml`: Linux builds on **ubuntu-22.04** (glibc 2.35 → runs on Debian 12, which died with "GLIBC_2.39 not found" on the 24.04-built binaries); adds the **ubuntu-22.04-arm** / aarch64 build.

After merging, the Release workflow will be re-dispatched with tag v0.2.0 to rebuild/replace the Linux assets on the existing release and add the arm64 one.

https://claude.ai/code/session_012HBi5A2gpLS8WzurJfqUG3

---
_Generated by [Claude Code](https://claude.ai/code/session_012HBi5A2gpLS8WzurJfqUG3)_