### PR TITLE
activity monitor: in-app panel + tuiui ps / kill-app CLI

### DIFF
--- a/.kilo/plans/activity-monitor.md
+++ b/.kilo/plans/activity-monitor.md
@@ -1,0 +1,146 @@
+# Activity Monitor + Blank-Shell Recovery
+
+## What I'm fixing
+
+You have a wedged `tuiui` stack and you want a built-in way to see and kill the apps `tuiui` is running.
+
+### Root cause of the blank shell (no code change required)
+
+From `ps`/`lsof`/socket ownership:
+
+| PID     | Role                       | Started          | Socket it owns                       | Notes                                                                                  |
+|---------|----------------------------|------------------|--------------------------------------|----------------------------------------------------------------------------------------|
+| `3194`  | `tuiui` front-end client   | Thu 18:17 (1d+)  | none (fds point at dead daemon peer) | **Stale** — orphan client attached to a long-gone daemon.                              |
+| `1633`  | `tuiui --apphost`          | Thu 18:17 (1d+)  | `apphost.sock`                       | Owns the live apps from yesterday.                                                     |
+| `86161` | `tuiui --daemon` (fresh)   | 7:53 pm (4 min)  | `daemon.sock`, `daemon-ctl.sock`     | Rebound the daemon socket; re-used the apphost already running.                        |
+| `90291` | `.kilo`                    | 7:54 pm (3 min)  | unix-pair to nothing                 | **R+ 100% CPU**, three orphaned socket fds → Kilo is spinning on broken pipes.         |
+
+The daemon's `serve_client` loop is **single-client-serial** (`src/daemon.rs:97` `for stream in listener.incoming()`). When a second `tuiui` client attached, the first one's stream was severed; the orphan is PID `3194`. The new Kilo window is blank because the apphost's Kilo child is wedged on dead sockets (100% CPU, no readable peer).
+
+**Claude Code sessions (PIDs `12013`, `10103`) are untouched.**
+
+### Recovery (no code, do this first)
+
+```bash
+kill 3194 1633 86161 90291 2>/dev/null
+rm -f /var/folders/gh/52p2m9rs61d04xmmbb4mxsnh0000gn/T/tuiui-jay/{daemon,daemon-ctl,apphost}.sock
+tuiui
+```
+
+This unblocks you immediately. Everything below is the new feature.
+
+---
+
+## What I'm building
+
+Two surfaces, both driving the same data:
+
+1. **CLI** — `tuiui ps` (list hosted apps) and `tuiui kill-app <id>` (kill one). Lives next to the existing `tuiui kill` / `tuiui reload` in `src/main.rs`. Uses the apphost socket directly, so it works from any TTY or over SSH.
+2. **In-app panel** — a new built-in window (`Ctrl+Space m`, plus a dock/menubar entry) showing a live, auto-refreshing table of hosted apps with `k` / `K` to kill, mirroring the Settings/Store/Filter pattern. No new process: it runs inside the existing daemon, which already has the `AppHost` trait handle.
+
+### CLI scope
+
+```
+$ tuiui ps
+APPID  PID     CMD                                 COLSxROWS  AGE     STATE
+1      58312   /opt/homebrew/bin/kilo              120x40     2m      alive
+2      —       /bin/zsh                            80x24      1h12m   alive
+3      —       /opt/homebrew/bin/lazygit           200x50     18s     dead (exit 0)
+
+$ tuiui kill-app 1
+tuiui: sent kill to app 1 (kilo, pid 58312)
+$ tuiui kill-app 999
+tuiui: no such app (have: 1, 2, 3)
+$ tuiui kill-app all
+tuiui: sent kill to 3 app(s)
+```
+
+- `tuiui ps` and `tuiui kill-app` are subcommands of the **front-end `tuiui` binary** in `src/main.rs` (not `--daemon` / `--apphost`). They connect to the apphost socket directly using the same path resolution as the daemon (`src/protocol.rs:118` `apphost_socket_path()`).
+- Both send a new apphost request and read a structured response, then exit. They do **not** require a client to be attached — they work even with `tuiui` running headless.
+- "age" comes from a spawn timestamp the apphost tracks (new field on `AppInstance`).
+- "pid" comes from `portable_pty::Child::process_id()` — already on the trait, just not surfaced.
+
+### In-app panel scope
+
+A new window "Activity Monitor", opened by:
+- `Ctrl+Space` → `m` (new leader binding, alongside `s`=Store, `,`=Settings).
+- An entry in the menubar (next to Store/Settings), and a launcher entry `@activity` for symmetry with `@store`/`@settings`/`@files`.
+
+Contents (a single screen, fixed-width table):
+
+```
+Activity Monitor                                3 apps   refresh: 1s
+─────────────────────────────────────────────────────────────────────
+  ID    PID      CMD                          COLS×ROWS  AGE    STATE
+▶  1   58312    /opt/homebrew/bin/kilo         120×40   2m     alive
+   2     —      /bin/zsh                        80×24   1h12m  alive
+   3     —      /opt/homebrew/bin/lazygit       200×50   18s    dead
+
+k: kill selected   K: kill all dead   r: refresh now   Esc: close
+```
+
+- **Auto-refresh**: re-pulls the list every 1s while the window is open and focused (timer in `daemon.rs`'s `serve_client` loop; only ticks when panel is focused so it costs nothing when closed).
+- **Keys**: `↑/↓` move, `k` kills the selected (with a confirm overlay like the titlebar ✕ close), `K` kills all `dead` rows (no confirm — these are already gone), `r` forces refresh, `Esc` closes.
+- **Click-to-kill**: clicking a row's `kill` glyph does the same as `k`. A click anywhere on the row selects it.
+- **No new process**: the panel reads the existing `AppHost` directly in-process. No apphost protocol change is needed for the panel itself.
+
+### Why I'm NOT touching the apphost protocol for the panel
+
+`SessionCore` already calls `host.list()`, `host.meta(id)`, and `host.is_alive(id)` every frame. I'll add two cheap reads:
+- `host.spawn_time(id) -> Option<Instant>` — new method on `AppHost`, default returns `None`. `LocalAppHost` returns `Some(self.spawned_at[&id])` (new field, set in `spawn`).
+- `host.pid(id) -> Option<u32>` — new method. `LocalAppHost` calls `self.apps[&id].child.process_id()` via a new `AppInstance::process_id()` (which `portable_pty::Child` already exposes).
+
+The CLI side does need a protocol change — see below.
+
+---
+
+## Files I'll touch
+
+| File                                       | What                                                                                                                                  |
+|--------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------|
+| `src/main.rs`                              | New subcommands `ps`, `kill-app`. Dispatch table in the `match` at `main.rs:20`. Two new free functions.                              |
+| `src/launcher.rs`                          | New `@activity` special-case alongside `@store`/`@settings`/`@files` at `session.rs:1755-1765` (actually that lives in session).       |
+| `src/session.rs`                           | `open_activity()` mirroring `open_settings()`/`open_store()`; new `ClientMsg::{OpenActivity, ActivityUp, ActivityDown, ActivityKill, ActivityKillDead, ActivityRefresh, ActivityClose}`; new `WinContent::Activity(Activity)`; `focused_is_activity()`, `activity_editing()` flags. New `Launcher::activity()` keyword. |
+| `src/activity.rs` *(new)*                  | The `Activity` widget — list of rows, selection, kill-confirm overlay. ~250 lines, patterned on `settings.rs` + `store.rs`.            |
+| `src/apphost/api.rs`                       | Add `spawn_time(id) -> Option<Instant>` and `pid(id) -> Option<u32>` to the trait (with defaults for back-compat).                   |
+| `src/apphost/host.rs`                      | Implement both on `LocalAppHost`. Store `Instant::now()` in a new `HashMap<AppId, Instant>`.                                          |
+| `src/ptyhost.rs`                           | Add `AppInstance::process_id() -> Option<u32>` (forwarding to `child.process_id()`); add a `spawned_at: Instant` field.                |
+| `src/protocol.rs`                          | Add the new `Flags` field `activity_focused: bool`.                                                                                  |
+| `src/client.rs`                            | In the key-routing `if/else` chain around line 169–235, add the `activity_focused` branch with the keys listed above.                 |
+| `src/daemon.rs`                            | Populate the new `Flags` field; if `activity_focused`, kick a refresh every 1s by calling `core.refresh_activity()` (a new method).   |
+| `src/apphost/proto.rs`                     | Add `HostReq::ListApps` (id+cmd+pid+cols+rows+age+alive) and `HostEvt::AppList { apps: Vec<AppInfo> }` for the CLI path.               |
+| `src/apphost/server.rs`                    | Handle `ListApps`: walk `local.list()`, build `AppInfo`s, send `AppList` back.                                                       |
+| `src/apphost/remote.rs`                    | Implement the new `spawn_time` and `pid` methods on `RemoteAppHost` (just return `None` for now — these are panel-only, in-process).  |
+| `src/main.rs` (CLI helper)                 | `fn cmd_ps()` and `fn cmd_kill_app(id: &str)`: connect to apphost, send `ListApps`, print, exit. Use `serde_json` for the wire format. |
+| `Cargo.toml`                               | No new deps. `portable_pty` and `serde_json` already in.                                                                             |
+| `tests/`                                   | One new test: spawn 3 apps via `RemoteAppHost::spawn` over a loopback socket, send `ListApps`, assert 3 rows. Reuse the pattern at `src/apphost/remote.rs:209-251`. |
+| `README.md`                                | Add `Ctrl+Space m` to the shortcuts table; add a one-liner for `tuiui ps`/`tuiui kill-app` next to `tuiui kill`/`reload` in the "Persistent daemon" paragraph. |
+
+## Things I'm explicitly NOT doing
+
+- **Not** changing the apphost `Kill` semantics (it already kills a single app by id). The CLI just dispatches the same `HostReq::Kill { app }`.
+- **Not** adding a force-kill / SIGKILL path. The portable-pty `Child::kill()` is the right level — process group, SIGTERM-equivalent on macOS/Linux.
+- **Not** showing the daemon/apphost processes themselves. The user's spec was "apps tuiui is managing"; those don't change per-launch and we already have `tuiui service status` for them.
+- **Not** adding a "kill all" key to the in-app panel (only `K` for "kill all dead", which is a no-cost cleanup). Closing the daemon is what `tuiui kill` is for.
+- **Not** touching the Claude Code sessions.
+
+## Verification
+
+```bash
+# Unit + integration tests (new + existing)
+cargo test --quiet
+# Lint
+cargo clippy --all-targets --quiet
+# Build
+cargo build --release
+
+# Manual: in one terminal
+tuiui &
+# launch a few apps from inside (e.g. via the launcher), then in a different TTY:
+tuiui ps                       # should show them
+tuiui kill-app 1               # kills app 1
+tuiui ps                       # app 1 gone
+# In the running tuiui, Ctrl+Space m should show the same list, with r/k working
+```
+
+The recovery commands at the top are independent of this work — you can run them now to get unstuck before any of the code is written.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ tuiui uses a **leader key** (`Ctrl+Space`) so its shortcuts never collide with m
 | `Ctrl+Space` then `T` | Toggle auto-tile mode |
 | `Ctrl+Space` then `1`–`9` | Send focused window to grid cell N |
 | `Ctrl+Space` then `s` / `,` | Open the Store / Settings |
+| `Ctrl+Space` then `A` | **Activity Monitor** — see and kill hosted apps |
 | `Ctrl+Space` then `r` | **Rename** the focused window (type a new name, Enter) |
 | `Ctrl+Space` then `?` | **Help** — show this shortcut cheatsheet in-app (any key dismisses) |
 | `Ctrl+Space` then `q` | Detach (apps keep running in the background) |
@@ -111,6 +112,8 @@ and it's all still there.
 tuiui            # ensure the daemon is running, then attach
 tuiui attach     # attach to an already-running daemon
 tuiui reload     # restart the UI only; apps keep running
+tuiui ps         # list every hosted app (id, pid, cmd, age, alive)
+tuiui kill-app <id|all>  # kill one (or every) hosted app
 tuiui kill       # shut the daemon down (closes all windows)
 
 # Control a running desktop from any shell (also how the AI assistant drives it):

--- a/src/activity.rs
+++ b/src/activity.rs
@@ -1,0 +1,421 @@
+//! The activity monitor panel: a live, auto-refreshing table of the apps the
+//! apphost is hosting, with kill-app keybinds. Mirrors the structure of
+//! [`crate::settings`] (state, render, hit-test) and is rendered into a
+//! window-sized `CellBuffer` each frame.
+//!
+//! The panel does **not** talk to the apphost itself — the session rebuilds the
+//! list from the in-process `AppHost` every frame and hands the resulting
+//! [`Snapshot`]s in via [`Activity::set_rows`]. That keeps the widget in-process
+//! and avoids a second protocol surface.
+
+use crate::apphost::AppListEntry;
+use crate::buffer::CellBuffer;
+use crate::cell::{Cell, Rgba};
+use crate::geometry::Point;
+
+const BG: Rgba = Rgba { r: 17, g: 20, b: 29, a: 255 };
+const FG: Rgba = Rgba { r: 200, g: 208, b: 220, a: 255 };
+const DIM: Rgba = Rgba { r: 120, g: 130, b: 150, a: 255 };
+const SEL_BG: Rgba = Rgba { r: 45, g: 58, b: 85, a: 255 };
+const ACCENT: Rgba = Rgba { r: 108, g: 182, b: 255, a: 255 };
+const RED: Rgba = Rgba { r: 241, g: 76, b: 76, a: 255 };
+
+/// In-progress kill confirmation: `Some((index, app_id))` while the user is
+/// being asked to confirm they really want to kill the selected app.
+#[derive(Clone, Copy)]
+struct PendingKill {
+    row: usize,
+    app: u64,
+}
+
+/// One row of the table, derived from an [`AppListEntry`] (the apphost reply to
+/// `ListApps`).
+struct Row {
+    entry: AppListEntry,
+}
+
+/// Activity monitor panel state.
+pub struct Activity {
+    rows: Vec<Row>,
+    selected: usize,
+    /// The refresh counter shown in the header; bumped whenever the session
+    /// hands us a new snapshot. Cosmetic, but useful when the list is
+    /// mysteriously stale.
+    refresh_count: u64,
+    /// Pending kill confirmation; while `Some`, the panel renders a modal
+    /// overlay and the next `Enter`/`y` confirms.
+    pending_kill: Option<PendingKill>,
+}
+
+impl Activity {
+    pub fn new() -> Self {
+        Self { rows: Vec::new(), selected: 0, refresh_count: 0, pending_kill: None }
+    }
+
+    /// Replace the table contents with a fresh snapshot from the apphost. The
+    /// session calls this every frame; when nothing has changed we still bump
+    /// the header counter so the user can see it's live.
+    pub fn set_rows(&mut self, entries: Vec<AppListEntry>) {
+        self.rows = entries.into_iter().map(|entry| Row { entry }).collect();
+        if self.selected >= self.rows.len() {
+            self.selected = self.rows.len().saturating_sub(1);
+        }
+        self.refresh_count = self.refresh_count.wrapping_add(1);
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.rows.is_empty()
+    }
+
+    /// Move the selection up one row (no-op if empty).
+    pub fn move_up(&mut self) {
+        if self.rows.is_empty() {
+            return;
+        }
+        self.selected = self.selected.saturating_sub(1);
+    }
+
+    /// Move the selection down one row (no-op if empty).
+    pub fn move_down(&mut self) {
+        if self.rows.is_empty() {
+            return;
+        }
+        if self.selected + 1 < self.rows.len() {
+            self.selected += 1;
+        }
+    }
+
+    /// Request to kill the currently selected row. Returns the app id to kill
+    /// (the session will dispatch the actual `HostReq::Kill`). If the user is
+    /// already in a confirm prompt, `Enter`/`y` here confirms and returns the
+    /// id; `Esc`/`n` cancels.
+    ///
+    /// Returns `Some(app_id)` to dispatch, `None` to do nothing.
+    pub fn request_kill_selected(&mut self) -> Option<u64> {
+        if let Some(pk) = self.pending_kill {
+            // Already in confirm mode — this Enter/y confirms.
+            self.pending_kill = None;
+            return Some(pk.app);
+        }
+        let row = self.rows.get(self.selected)?;
+        if !row.entry.alive {
+            // Dead rows can be cleaned up immediately (no confirm needed).
+            return Some(row.entry.app);
+        }
+        self.pending_kill = Some(PendingKill { row: self.selected, app: row.entry.app });
+        None
+    }
+
+    /// Dismiss the pending kill confirmation, if any.
+    pub fn cancel_kill(&mut self) {
+        self.pending_kill = None;
+    }
+
+    /// Whether a kill-confirm overlay is currently being shown.
+    pub fn has_pending_kill(&self) -> bool {
+        self.pending_kill.is_some()
+    }
+
+    /// Kill every row in the `dead` state. Returns the app ids to dispatch.
+    /// Intended to be triggered by the `K` keybind — safe with no confirm
+    /// because the processes are already gone.
+    pub fn kill_dead(&self) -> Vec<u64> {
+        self.rows.iter().filter(|r| !r.entry.alive).map(|r| r.entry.app).collect()
+    }
+
+    /// Handle a click inside the panel; returns the app id to kill if a
+    /// kill-button was clicked, or `None`. `w` is the panel's rendered width
+    /// (so the click hit-test matches what was painted).
+    pub fn handle_click(&mut self, p: Point, w: i32) -> Option<u64> {
+        // Clicks anywhere on the confirm overlay cancel it.
+        if self.pending_kill.is_some() {
+            self.pending_kill = None;
+            return None;
+        }
+        let header_y = 3;
+        let cols = ColumnLayout::for_width(w);
+        let row_y = header_y + 2 + self.selected as i32;
+        if p.y == row_y && p.x >= cols.kill && p.x < cols.kill + 4 {
+            self.request_kill_selected()
+        } else if p.y >= header_y + 2 && p.y < header_y + 2 + self.rows.len() as i32 {
+            self.selected = (p.y - header_y - 2) as usize;
+            None
+        } else {
+            None
+        }
+    }
+
+    /// Render the panel into a `w × h` content buffer.
+    pub fn render(&self, w: i32, h: i32) -> CellBuffer {
+        let mut buf = CellBuffer::new(w, h);
+        buf.fill(Cell { ch: ' ', fg: FG, bg: BG, attrs: Default::default() });
+
+        // Header bar: title + count + refresh counter.
+        let title = "Activity Monitor";
+        buf.write_str(2, 1, title, ACCENT, BG);
+        let count = format!("{} app{}", self.rows.len(), if self.rows.len() == 1 { "" } else { "s" });
+        buf.write_str(2 + title.chars().count() as i32 + 2, 1, &count, DIM, BG);
+        let refresh = format!("refresh: #{}", self.refresh_count);
+        buf.write_str(w - refresh.chars().count() as i32 - 2, 1, &refresh, DIM, BG);
+
+        // Column headers.
+        let header_y = 3;
+        let cols = ColumnLayout::for_width(w);
+        buf.write_str(cols.id, header_y, "ID", DIM, BG);
+        buf.write_str(cols.pid, header_y, "PID", DIM, BG);
+        buf.write_str(cols.cmd, header_y, "CMD", DIM, BG);
+        buf.write_str(cols.dims, header_y, "COLS×ROWS", DIM, BG);
+        buf.write_str(cols.age, header_y, "AGE", DIM, BG);
+        buf.write_str(cols.state, header_y, "STATE", DIM, BG);
+        buf.write_str(cols.kill, header_y, "KILL", DIM, BG);
+
+        // Divider under the header.
+        for x in 1..(w - 1) {
+            buf.set(x, header_y + 1, Cell { ch: '─', fg: DIM, bg: BG, attrs: Default::default() });
+        }
+
+        if self.rows.is_empty() {
+            buf.write_str(
+                (w / 2 - 10).max(1),
+                header_y + 3,
+                "no apps running",
+                DIM,
+                BG,
+            );
+        } else {
+            // List rows.
+            let mut y = header_y + 2;
+            for (i, row) in self.rows.iter().enumerate() {
+                let sel = i == self.selected;
+                let row_bg = if sel { SEL_BG } else { BG };
+                if sel {
+                    for x in 0..w {
+                        buf.set(x, y, Cell { ch: ' ', fg: FG, bg: row_bg, attrs: Default::default() });
+                    }
+                }
+                let fg = if sel { FG } else { DIM };
+                buf.write_str(cols.id, y, &format!("{}", row.entry.app), fg, row_bg);
+                let pid = row.entry.pid.map(|p| p.to_string()).unwrap_or_else(|| "—".into());
+                buf.write_str(cols.pid, y, &pid, fg, row_bg);
+                let cmdline = format_cmdline(&row.entry.cmd, &row.entry.args);
+                let max_cmd = (cols.dims - cols.cmd - 1).max(4) as usize;
+                buf.write_str(cols.cmd, y, &truncate(&cmdline, max_cmd), fg, row_bg);
+                buf.write_str(
+                    cols.dims,
+                    y,
+                    &format!("{}×{}", row.entry.cols, row.entry.rows),
+                    fg,
+                    row_bg,
+                );
+                buf.write_str(cols.age, y, &format_age(row.entry.age_secs), fg, row_bg);
+                let (state_text, state_col) = if row.entry.alive { ("alive", FG) } else { ("dead", DIM) };
+                buf.write_str(cols.state, y, state_text, state_col, row_bg);
+
+                // Kill button on the selected row (red glyph).
+                if sel {
+                    buf.write_str(cols.kill, y, "kill", RED, row_bg);
+                } else {
+                    buf.write_str(cols.kill, y, "    ", FG, row_bg);
+                }
+
+                y += 1;
+                if y >= h - 4 {
+                    break;
+                }
+            }
+        }
+
+        // Footer help line.
+        let footer_y = h - 2;
+        let footer = "↑↓ select · k kill selected · K kill all dead · r refresh · Esc close";
+        let fx = ((w - footer.chars().count() as i32) / 2).max(1);
+        buf.write_str(fx, footer_y, footer, DIM, BG);
+
+        // Optional confirm overlay.
+        if let Some(pk) = self.pending_kill {
+            self.render_confirm(&mut buf, w, h, pk);
+        }
+
+        buf
+    }
+
+    fn render_confirm(&self, buf: &mut CellBuffer, w: i32, h: i32, pk: PendingKill) {
+        let cmdline = self
+            .rows
+            .get(pk.row)
+            .map(|r| format_cmdline(&r.entry.cmd, &r.entry.args))
+            .unwrap_or_default();
+        let label = format!("Kill app {} ({})?  [Enter/y confirm · Esc/n cancel]", pk.app, cmdline);
+        let box_w = (label.chars().count() as i32 + 4).min(w - 2).max(20);
+        let box_h = 3;
+        let ox = (w - box_w) / 2;
+        let oy = (h - box_h) / 2;
+        let bg = Rgba { r: 45, g: 0, b: 0, a: 255 };
+        for x in ox..(ox + box_w) {
+            for y in oy..(oy + box_h) {
+                buf.set(x, y, Cell { ch: ' ', fg: FG, bg, attrs: Default::default() });
+            }
+        }
+        buf.write_str(ox + 2, oy + 1, &label, RED, bg);
+    }
+}
+
+impl Default for Activity {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Column x-offsets (kept in one place so header + rows stay aligned).
+struct ColumnLayout {
+    id: i32,
+    pid: i32,
+    cmd: i32,
+    dims: i32,
+    age: i32,
+    state: i32,
+    kill: i32,
+}
+
+impl ColumnLayout {
+    fn for_width(w: i32) -> Self {
+        // Reserve 2 cells of left padding, then fixed-width columns.
+        let id = 2;
+        let pid = id + 6; // " 12345"
+        let cmd = pid + 9; // "  1234567"
+        let dims = cmd + 30; // 28 for cmd + 2 padding
+        let age = dims + 12; // " 9999×9999 "
+        let state = age + 10; // " 9999d99h "
+        let kill = state + 8; // " alive "
+        // If we don't have room for the kill column, fold it into state.
+        if kill + 6 > w {
+            ColumnLayout { id, pid, cmd, dims, age, state, kill: w - 6 }
+        } else {
+            ColumnLayout { id, pid, cmd, dims, age, state, kill }
+        }
+    }
+}
+
+fn format_cmdline(cmd: &str, args: &[String]) -> String {
+    if args.is_empty() {
+        cmd.to_string()
+    } else {
+        format!("{} {}", cmd, args.join(" "))
+    }
+}
+
+fn format_age(secs: u64) -> String {
+    if secs < 60 {
+        format!("{secs}s")
+    } else if secs < 60 * 60 {
+        format!("{}m{:02}s", secs / 60, secs % 60)
+    } else if secs < 24 * 60 * 60 {
+        format!("{}h{:02}m", secs / 3600, (secs / 60) % 60)
+    } else {
+        format!("{}d{:02}h", secs / 86400, (secs / 3600) % 24)
+    }
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        s.to_string()
+    } else {
+        let keep = max.saturating_sub(1);
+        format!("{}\u{2026}", s.chars().take(keep).collect::<String>())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(app: u64, alive: bool) -> AppListEntry {
+        AppListEntry {
+            app,
+            cmd: "/bin/echo".into(),
+            args: vec!["hi".into()],
+            pid: Some(1000 + app as u32),
+            cols: 80,
+            rows: 24,
+            age_secs: 90,
+            alive,
+        }
+    }
+
+    #[test]
+    fn empty_panel_renders_with_placeholder() {
+        let a = Activity::new();
+        let buf = a.render(80, 20);
+        // No rows → "no apps running" message somewhere.
+        let mut found = false;
+        for y in 0..20 {
+            for x in 0..80 {
+                if let Some(c) = buf.get(x, y) {
+                    if c.ch == 'n' {
+                        // crude, but enough: the placeholder is on its own row
+                        found = true;
+                    }
+                }
+            }
+        }
+        assert!(found, "expected some text in the empty panel");
+    }
+
+    #[test]
+    fn selection_clamps_when_rows_shrink() {
+        let mut a = Activity::new();
+        a.set_rows(vec![entry(1, true), entry(2, true), entry(3, true)]);
+        a.move_down();
+        a.move_down();
+        a.move_down(); // past the end
+        assert_eq!(a.selected, 2);
+        a.set_rows(vec![entry(1, true)]);
+        assert_eq!(a.selected, 0);
+    }
+
+    #[test]
+    fn kill_dead_returns_only_dead() {
+        let mut a = Activity::new();
+        a.set_rows(vec![entry(1, true), entry(2, false), entry(3, false)]);
+        assert_eq!(a.kill_dead(), vec![2, 3]);
+    }
+
+    #[test]
+    fn kill_live_row_requires_confirm() {
+        let mut a = Activity::new();
+        a.set_rows(vec![entry(1, true), entry(2, false)]);
+        a.move_down();
+        a.move_down();
+        // selected = 1, dead → kills immediately, no confirm.
+        assert_eq!(a.request_kill_selected(), Some(2));
+        assert!(!a.has_pending_kill());
+        // selected = 0, live → first Enter asks for confirm, second confirms.
+        a.selected = 0;
+        assert_eq!(a.request_kill_selected(), None);
+        assert!(a.has_pending_kill());
+        assert_eq!(a.request_kill_selected(), Some(1));
+        assert!(!a.has_pending_kill());
+    }
+
+    #[test]
+    fn cancel_drops_pending_kill() {
+        let mut a = Activity::new();
+        a.set_rows(vec![entry(7, true)]);
+        a.request_kill_selected();
+        assert!(a.has_pending_kill());
+        a.cancel_kill();
+        assert!(!a.has_pending_kill());
+    }
+
+    #[test]
+    fn age_formatting() {
+        assert_eq!(format_age(0), "0s");
+        assert_eq!(format_age(59), "59s");
+        assert_eq!(format_age(60), "1m00s");
+        assert_eq!(format_age(125), "2m05s");
+        assert_eq!(format_age(3600), "1h00m");
+        assert_eq!(format_age(3725), "1h02m");
+        assert_eq!(format_age(86400), "1d00h");
+        assert_eq!(format_age(90061), "1d01h");
+    }
+}

--- a/src/apphost/api.rs
+++ b/src/apphost/api.rs
@@ -68,6 +68,14 @@ pub trait AppHost: Send {
     /// The app's latest OSC-52 clipboard store, if any (drained; default none).
     fn take_clipboard(&mut self, _id: AppId) -> Option<String> { None }
 
+    /// The child process's OS pid, if known. Default returns `None` (the remote
+    /// host doesn't surface this to its in-process callers).
+    fn pid(&self, _id: AppId) -> Option<u32> { None }
+
+    /// The wall-clock instant the app was spawned, if known. Default returns
+    /// `None` (the remote host doesn't surface this to its in-process callers).
+    fn spawn_time(&self, _id: AppId) -> Option<std::time::Instant> { None }
+
     /// The app's current terminal mouse mode (default = no mouse).
     fn mouse_mode(&self, id: AppId) -> crate::mouse::AppMouse { let _ = id; crate::mouse::AppMouse::default() }
 

--- a/src/apphost/host.rs
+++ b/src/apphost/host.rs
@@ -17,12 +17,26 @@ pub struct AppId(pub u64);
 pub struct LocalAppHost {
     apps: HashMap<AppId, AppInstance>,
     meta: HashMap<AppId, Vec<u8>>,
+    /// Original `cmd` + `args` for each hosted app, so the activity monitor
+    /// (`tuiui ps`, the in-app panel) can display what was actually launched
+    /// even after the `AppInstance`'s internal state changes.
+    cmds: HashMap<AppId, (String, Vec<String>)>,
     next: u64,
 }
 
 impl LocalAppHost {
     pub fn new() -> Self {
-        LocalAppHost { apps: HashMap::new(), meta: HashMap::new(), next: 1 }
+        LocalAppHost { apps: HashMap::new(), meta: HashMap::new(), cmds: HashMap::new(), next: 1 }
+    }
+
+    /// The original `cmd` + `args` used to spawn the app, if known.
+    pub fn launch_cmd(&self, id: AppId) -> Option<(&str, &[String])> {
+        self.cmds.get(&id).map(|(c, a)| (c.as_str(), a.as_slice()))
+    }
+
+    /// The requested terminal size for the app, if it has a snapshot.
+    pub fn dims(&self, id: AppId) -> Option<(i32, i32)> {
+        self.apps.get(&id).map(|a| (a.snapshot().width(), a.snapshot().height()))
     }
 }
 
@@ -46,6 +60,7 @@ impl AppHost for LocalAppHost {
         let id = AppId(self.next);
         self.next += 1;
         self.apps.insert(id, app);
+        self.cmds.insert(id, (cmd.to_string(), args.to_vec()));
         Ok(id)
     }
 
@@ -115,6 +130,15 @@ impl AppHost for LocalAppHost {
     fn remove(&mut self, id: AppId) {
         self.apps.remove(&id);
         self.meta.remove(&id);
+        self.cmds.remove(&id);
+    }
+
+    fn pid(&self, id: AppId) -> Option<u32> {
+        self.apps.get(&id).and_then(|a| a.process_id())
+    }
+
+    fn spawn_time(&self, id: AppId) -> Option<std::time::Instant> {
+        self.apps.get(&id).map(|a| a.spawned_at())
     }
 
     fn mouse_mode(&self, id: AppId) -> crate::mouse::AppMouse {

--- a/src/apphost/mod.rs
+++ b/src/apphost/mod.rs
@@ -14,4 +14,5 @@ mod remote;
 
 pub use api::AppHost;
 pub use host::{AppId, LocalAppHost};
+pub use proto::{AppListEntry, HostEvt, HostReq};
 pub use remote::RemoteAppHost;

--- a/src/apphost/proto.rs
+++ b/src/apphost/proto.rs
@@ -17,6 +17,9 @@ pub enum HostReq {
     Scroll { app: u64, lines: i32 },
     SetMeta { app: u64, meta: Vec<u8> },
     Kill { app: u64 },
+    /// Ask the apphost to enumerate its hosted apps. The apphost replies with
+    /// `HostEvt::AppList`. Used by `tuiui ps` / `tuiui kill-app`.
+    ListApps,
     /// Stop the apphost process entirely (full shutdown / `tuiui kill`).
     Shutdown,
 }
@@ -44,6 +47,21 @@ pub const MIN_COMPAT: u32 = 0;
 pub struct RosterEntry {
     pub app: u64,
     pub meta: Vec<u8>,
+}
+
+/// One row in `HostEvt::AppList` — a snapshot of a hosted app's state. Used by
+/// `tuiui ps`. `age_secs` is seconds since the app was spawned (so the client
+/// doesn't need a synchronized clock with the apphost).
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct AppListEntry {
+    pub app: u64,
+    pub cmd: String,
+    pub args: Vec<String>,
+    pub pid: Option<u32>,
+    pub cols: i32,
+    pub rows: i32,
+    pub age_secs: u64,
+    pub alive: bool,
 }
 
 /// apphost → frontend.
@@ -75,6 +93,8 @@ pub enum HostEvt {
         #[serde(default)]
         proto: u32,
     },
+    /// Reply to `HostReq::ListApps`.
+    AppList { apps: Vec<AppListEntry> },
 }
 
 /// Write a newline-JSON message. Returns `Err` if the peer is gone.
@@ -127,6 +147,7 @@ mod tests {
             HostReq::Resize { app: 3, cols: 100, rows: 40 },
             HostReq::SetMeta { app: 3, meta: vec![9, 9] },
             HostReq::Kill { app: 3 },
+            HostReq::ListApps,
             HostReq::Shutdown,
         ];
         for m in msgs {

--- a/src/apphost/remote.rs
+++ b/src/apphost/remote.rs
@@ -128,6 +128,11 @@ fn apply_evt(evt: HostEvt, cache: &Arc<Mutex<Cache>>, pending: &Pending) {
                 c.apps.entry(id).or_default().alive = true;
             }
         }
+        HostEvt::AppList { .. } => {
+            // Reply to HostReq::ListApps (used by `tuiui ps` / `tuiui kill-app`).
+            // The remote handle isn't the consumer — those CLI commands open a
+            // short-lived connection and read the reply themselves, so we drop it.
+        }
     }
 }
 
@@ -275,6 +280,90 @@ mod tests {
 
         remote.kill(id);
         remote.shutdown_apphost();
+        let _ = std::fs::remove_file(&path);
+        let _ = server.join();
+    }
+
+    /// `tuiui ps` / `tuiui kill-app` depend on `ListApps` round-tripping
+    /// correctly through a real server connection. Spawn 3 apps, list, assert
+    /// the apphost reports 3 rows with the expected fields.
+    #[test]
+    fn loopback_list_apps_round_trip() {
+        use crate::apphost::proto::{send, HostEvt, HostReq};
+        use std::io::BufReader;
+
+        let path = crate::protocol::socket_dir().join("apphost-list-test.sock");
+        let dir = crate::protocol::socket_dir();
+        std::fs::create_dir_all(&dir).unwrap();
+        let _ = std::fs::remove_file(&path);
+        let listener = std::os::unix::net::UnixListener::bind(&path).unwrap();
+
+        let server = std::thread::spawn(move || {
+            use crate::apphost::LocalAppHost;
+            let mut local = LocalAppHost::new();
+            let mut shutdown = false;
+            if let Some(Ok(stream)) = listener.incoming().next() {
+                crate::apphost::server::server_serve_for_test(&mut local, stream, &mut shutdown);
+            }
+        });
+
+        std::thread::sleep(Duration::from_millis(50));
+        let mut writer = UnixStream::connect(&path).unwrap();
+        let mut r = BufReader::new(writer.try_clone().unwrap());
+
+        // Spawn three apps, then ask for the list. The server processes
+        // commands synchronously, so by the time we read AppList all three
+        // apps are registered with the shared LocalAppHost.
+        for i in 1..=3u64 {
+            send(
+                &mut writer,
+                &HostReq::Spawn {
+                    req_id: i,
+                    // Long-lived sleep so the child is alive when we read
+                    // the AppList. `true` exits instantly and trips
+                    // is_alive.
+                    cmd: "sh".into(),
+                    args: vec!["-c".into(), "sleep 30".into()],
+                    cwd: None,
+                    cols: 80,
+                    rows: 24,
+                },
+            )
+            .unwrap();
+        }
+        send(&mut writer, &HostReq::ListApps).unwrap();
+
+        // A background reader drains the apphost's frame stream so the
+        // server's `send` never blocks on a full kernel buffer. We pass the
+        // AppList back through a oneshot channel and ignore everything else.
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || loop {
+            match crate::apphost::proto::recv::<HostEvt, _>(&mut r) {
+                Ok(Some(HostEvt::AppList { apps })) => {
+                    let _ = tx.send(apps);
+                    // Keep reading: server will continue pushing Frames until
+                    // we close the socket. Ignore them.
+                }
+                Ok(Some(_)) => continue,
+                Ok(None) | Err(_) => break,
+            }
+        });
+        let apps = rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("timeout waiting for AppList");
+        assert_eq!(apps.len(), 3, "expected 3 rows, got {apps:?}");
+        for a in &apps {
+            assert_eq!(a.cmd, "sh");
+            assert!(a.pid.is_some(), "spawned app must have a pid");
+            assert!(a.alive, "freshly spawned sh -c sleep 30 should be alive");
+            assert_eq!(a.cols, 80);
+            assert_eq!(a.rows, 24);
+        }
+
+        // Tell the apphost to shut down; the background reader will hit EOF
+        // and exit, the server returns, the thread joins.
+        send(&mut writer, &HostReq::Shutdown).unwrap();
+        drop(writer);
         let _ = std::fs::remove_file(&path);
         let _ = server.join();
     }

--- a/src/apphost/server.rs
+++ b/src/apphost/server.rs
@@ -3,7 +3,7 @@
 //! (normally spawned automatically by the frontend daemon). The apps it owns
 //! survive a frontend restart because this process keeps running.
 
-use crate::apphost::proto::{recv, send, HostEvt, HostReq, ImgBlob, RosterEntry};
+use crate::apphost::proto::{recv, send, AppListEntry, HostEvt, HostReq, ImgBlob, RosterEntry};
 use crate::apphost::{AppHost, AppId, LocalAppHost};
 use crate::protocol::{apphost_socket_path, socket_dir};
 use std::collections::{HashMap, HashSet};
@@ -109,6 +109,34 @@ fn serve_frontend(local: &mut LocalAppHost, stream: UnixStream, shutdown: &mut b
                 Ok(HostReq::Scroll { app, lines }) => local.scroll(AppId(app), lines),
                 Ok(HostReq::SetMeta { app, meta }) => local.set_meta(AppId(app), meta),
                 Ok(HostReq::Kill { app }) => local.kill(AppId(app)),
+                Ok(HostReq::ListApps) => {
+                    let now = std::time::Instant::now();
+                    let mut apps = Vec::new();
+                    for id in local.list() {
+                        let (cmd, args) = local
+                            .launch_cmd(id)
+                            .map(|(c, a)| (c.to_string(), a.to_vec()))
+                            .unwrap_or_else(|| (String::new(), Vec::new()));
+                        let (cols, rows) = local.dims(id).unwrap_or((0, 0));
+                        let age_secs = local
+                            .spawn_time(id)
+                            .map(|t| now.duration_since(t).as_secs())
+                            .unwrap_or(0);
+                        apps.push(AppListEntry {
+                            app: id.0,
+                            cmd,
+                            args,
+                            pid: local.pid(id),
+                            cols,
+                            rows,
+                            age_secs,
+                            alive: local.is_alive(id),
+                        });
+                    }
+                    if send(&mut writer, &HostEvt::AppList { apps }).is_err() {
+                        return;
+                    }
+                }
                 Ok(HostReq::Shutdown) => {
                     *shutdown = true;
                     return;

--- a/src/client.rs
+++ b/src/client.rs
@@ -161,13 +161,14 @@ pub fn run(stream: UnixStream) -> std::io::Result<ClientExit> {
                         leader = false;
                         match k.code {
                             KeyCode::Char(' ') => send(&mut out_stream, &ClientMsg::ToggleSpotlight)?,
-                            KeyCode::Char('a') | KeyCode::Char('A') => send(&mut out_stream, &ClientMsg::ToggleMenu)?,
+                            KeyCode::Char('a') => send(&mut out_stream, &ClientMsg::ToggleMenu)?,
                             KeyCode::Char('m') | KeyCode::Char('M') => send(&mut out_stream, &ClientMsg::MaximizeFocused)?,
                             KeyCode::Char('n') | KeyCode::Char('N') => send(&mut out_stream, &ClientMsg::MinimizeFocused)?,
                             KeyCode::Char('[') | KeyCode::Left => send(&mut out_stream, &ClientMsg::SnapFocused(SnapZone::Left))?,
                             KeyCode::Char(']') | KeyCode::Right => send(&mut out_stream, &ClientMsg::SnapFocused(SnapZone::Right))?,
                             KeyCode::Char('s') | KeyCode::Char('S') => send(&mut out_stream, &ClientMsg::OpenStore)?,
                             KeyCode::Char(',') => send(&mut out_stream, &ClientMsg::OpenSettings)?,
+                            KeyCode::Char('A') => send(&mut out_stream, &ClientMsg::OpenActivity)?,
                             KeyCode::Char('?') | KeyCode::Char('h') => send(&mut out_stream, &ClientMsg::ToggleHelp)?,
                             KeyCode::Char('r') | KeyCode::Char('R') => send(&mut out_stream, &ClientMsg::RenameFocused)?,
                             KeyCode::Char('t') => send(&mut out_stream, &ClientMsg::TileAll)?,
@@ -257,6 +258,23 @@ pub fn run(stream: UnixStream) -> std::io::Result<ClientExit> {
                             KeyCode::Left => send(&mut out_stream, &ClientMsg::SettingsLeft)?,
                             KeyCode::Right => send(&mut out_stream, &ClientMsg::SettingsRight)?,
                             KeyCode::Enter | KeyCode::Char(' ') => send(&mut out_stream, &ClientMsg::SettingsToggle)?,
+                            _ => {}
+                        }
+                    } else if f.activity_focused && f.activity_confirming {
+                        // Kill-confirm overlay: Enter / y confirm, Esc / n cancel.
+                        match k.code {
+                            KeyCode::Esc | KeyCode::Char('n') | KeyCode::Char('N') => send(&mut out_stream, &ClientMsg::ActivityCancelKill)?,
+                            KeyCode::Enter | KeyCode::Char('y') | KeyCode::Char('Y') => send(&mut out_stream, &ClientMsg::ActivityConfirmKill)?,
+                            _ => {}
+                        }
+                    } else if f.activity_focused {
+                        match k.code {
+                            KeyCode::Esc => send(&mut out_stream, &ClientMsg::ActivityClose)?,
+                            KeyCode::Up => send(&mut out_stream, &ClientMsg::ActivityUp)?,
+                            KeyCode::Down => send(&mut out_stream, &ClientMsg::ActivityDown)?,
+                            KeyCode::Enter | KeyCode::Char('k') => send(&mut out_stream, &ClientMsg::ActivityKill)?,
+                            KeyCode::Char('K') => send(&mut out_stream, &ClientMsg::ActivityKillDead)?,
+                            KeyCode::Char('r') | KeyCode::Char('R') => send(&mut out_stream, &ClientMsg::ActivityRefresh)?,
                             _ => {}
                         }
                     } else if f.filemanager_focused && f.filemanager_editing {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -253,6 +253,7 @@ fn serve_client(
         core.refresh_app_graphics();
         core.sync_app_meta();
         core.pump_thumbnails();
+        core.refresh_activity();
         let frame = core.build_frame();
         comp.composite(&frame.layers, frame.cursor);
         let changes = comp.diff();
@@ -272,6 +273,8 @@ fn serve_client(
             confirm_close: core.confirm_close_open(),
             power_editing: core.power_form_editing(),
             logs_focused: core.focused_is_logs(),
+            activity_focused: core.focused_is_activity(),
+            activity_confirming: core.activity_confirming(),
             detach: core.quit_requested(),
             reload: core.reload_requested(),
             app_area: core.app_mouse_area(),

--- a/src/help.rs
+++ b/src/help.rs
@@ -37,6 +37,7 @@ pub fn help_sections() -> &'static [HelpSection] {
                 ("Space", "spotlight search"),
                 ("a", "app menu"),
                 ("s / ,", "store / settings"),
+                ("A", "activity monitor"),
             ],
         },
         HelpSection {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod chrome;
 pub mod catalog;
 pub mod store;
 pub mod settings;
+pub mod activity;
 pub mod launcher;
 pub mod powermenu;
 pub mod confirmclose;

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,13 +21,18 @@ use std::time::Duration;
 use tuiui::protocol::socket_path;
 
 fn main() -> std::io::Result<()> {
-    match std::env::args().nth(1).as_deref() {
+    let mut args = std::env::args().skip(1);
+    let cmd = args.next();
+    let rest: Vec<String> = args.collect();
+    match cmd.as_deref() {
         Some("--daemon") => tuiui::daemon::run(),
         Some("--apphost") => tuiui::apphost::server::run(),
         Some("kill") => kill(),
+        Some("kill-app") => kill_app(&rest),
+        Some("ps") => ps(),
         Some("attach") => attach(false),
         Some("reload") => reload(),
-        Some("service") => match std::env::args().nth(2).as_deref() {
+        Some("service") => match rest.first().map(String::as_str) {
             Some("install") => tuiui::service::install(),
             Some("uninstall") => tuiui::service::uninstall(),
             Some("status") | None => tuiui::service::status(),
@@ -69,7 +74,7 @@ fn main() -> std::io::Result<()> {
         },
         Some(other) => {
             eprintln!(
-                "tuiui: unknown command '{other}' (try: attach, kill, reload, launch, tile, theme, msg, service, --daemon)"
+                "tuiui: unknown command '{other}' (try: attach, kill, kill-app, ps, reload, launch, tile, theme, msg, service, --daemon)"
             );
             Ok(())
         }
@@ -274,6 +279,171 @@ fn kill() -> std::io::Result<()> {
             buf.push(b'\n');
             let _ = send_and_drain(&mut s, &buf);
         }
+    }
+    Ok(())
+}
+
+/// Format a `secs` duration as a short human-readable age ("12s", "3m", "1h12m",
+/// "2d04h"). Used by `tuiui ps` and the in-app activity monitor.
+fn format_age(secs: u64) -> String {
+    if secs < 60 {
+        format!("{secs}s")
+    } else if secs < 60 * 60 {
+        format!("{}m{:02}s", secs / 60, secs % 60)
+    } else if secs < 24 * 60 * 60 {
+        format!("{}h{:02}m", secs / 3600, (secs / 60) % 60)
+    } else {
+        format!("{}d{:02}h", secs / 86400, (secs / 3600) % 24)
+    }
+}
+
+fn format_cmdline(cmd: &str, args: &[String]) -> String {
+    if args.is_empty() {
+        cmd.to_string()
+    } else {
+        format!("{} {}", cmd, args.join(" "))
+    }
+}
+
+/// Connect to the apphost socket, send one `ListApps` request, and print the
+/// result as a fixed-width table. Errors with a clean message if the apphost
+/// isn't running.
+fn ps() -> std::io::Result<()> {
+    let path = tuiui::protocol::apphost_socket_path();
+    let mut s = match UnixStream::connect(&path) {
+        Ok(s) => s,
+        Err(_) => {
+            eprintln!("tuiui ps: no apphost running (start it with `tuiui`)");
+            std::process::exit(1);
+        }
+    };
+    use tuiui::apphost::proto::{send, HostEvt, HostReq};
+    send(&mut s, &HostReq::ListApps)?;
+    let mut r = std::io::BufReader::new(s);
+    let evt: HostEvt = match tuiui::apphost::proto::recv(&mut r)? {
+        Some(e) => e,
+        None => {
+            eprintln!("tuiui ps: apphost closed before replying");
+            std::process::exit(1);
+        }
+    };
+    let apps = match evt {
+        HostEvt::AppList { apps } => apps,
+        other => {
+            eprintln!("tuiui ps: unexpected reply: {other:?}");
+            std::process::exit(1);
+        }
+    };
+    if apps.is_empty() {
+        println!("(no apps running)");
+        return Ok(());
+    }
+    println!(
+        "{:>5}  {:>7}  {:<32}  {:>10}  {:>7}  STATE",
+        "APPID", "PID", "CMD", "COLSxROWS", "AGE"
+    );
+    for a in &apps {
+        let pid = a.pid.map(|p| p.to_string()).unwrap_or_else(|| "—".into());
+        let cmdline = format_cmdline(&a.cmd, &a.args);
+        let cmdline = if cmdline.chars().count() > 60 {
+            let mut s: String = cmdline.chars().take(59).collect();
+            s.push('…');
+            s
+        } else {
+            cmdline
+        };
+        let state = if a.alive { "alive" } else { "dead" };
+        println!(
+            "{:>5}  {:>7}  {:<32}  {:>4}x{:<4}  {:>7}  {}",
+            a.app,
+            pid,
+            cmdline,
+            a.cols,
+            a.rows,
+            format_age(a.age_secs),
+            state,
+        );
+    }
+    Ok(())
+}
+
+/// `tuiui kill-app <id|all>` — send `HostReq::Kill` for one (or all dead)
+/// hosted apps. `<id>` may be the apphost's numeric AppId. `all` kills every
+/// currently-known app. Errors clearly when the apphost isn't running.
+fn kill_app(args: &[String]) -> std::io::Result<()> {
+    use tuiui::apphost::proto::{send, HostEvt, HostReq};
+    let target = match args.first().map(String::as_str) {
+        Some(t) => t,
+        None => {
+            eprintln!("usage: tuiui kill-app <id|all>");
+            std::process::exit(2);
+        }
+    };
+    let path = tuiui::protocol::apphost_socket_path();
+    let mut s = match UnixStream::connect(&path) {
+        Ok(s) => s,
+        Err(_) => {
+            eprintln!("tuiui kill-app: no apphost running (start it with `tuiui`)");
+            std::process::exit(1);
+        }
+    };
+    send(&mut s, &HostReq::ListApps)?;
+    let mut r = std::io::BufReader::new(s);
+    let evt: HostEvt = match tuiui::apphost::proto::recv(&mut r)? {
+        Some(e) => e,
+        None => {
+            eprintln!("tuiui kill-app: apphost closed before replying");
+            std::process::exit(1);
+        }
+    };
+    let apps = match evt {
+        HostEvt::AppList { apps } => apps,
+        _ => {
+            eprintln!("tuiui kill-app: unexpected reply");
+            std::process::exit(1);
+        }
+    };
+    let to_kill: Vec<u64> = if target == "all" {
+        apps.iter().map(|a| a.app).collect()
+    } else {
+        let id: u64 = match target.parse() {
+            Ok(n) => n,
+            Err(_) => {
+                eprintln!("tuiui kill-app: '{target}' is not a numeric id or 'all'");
+                std::process::exit(2);
+            }
+        };
+        if !apps.iter().any(|a| a.app == id) {
+            let known: Vec<String> = apps.iter().map(|a| a.app.to_string()).collect();
+            eprintln!(
+                "tuiui kill-app: no such app (have: {})",
+                if known.is_empty() { "(none)".into() } else { known.join(", ") }
+            );
+            std::process::exit(1);
+        }
+        vec![id]
+    };
+    if to_kill.is_empty() {
+        println!("tuiui kill-app: no apps to kill");
+        return Ok(());
+    }
+    // Reconnect for each Kill — the previous connection's reader consumed
+    // the ListApps reply and would also consume any further reply we don't
+    // expect, so the cleanest path is one short-lived connection per Kill.
+    for id in &to_kill {
+        let mut s = match UnixStream::connect(&path) {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!("tuiui kill-app: connect failed: {e}");
+                std::process::exit(1);
+            }
+        };
+        send(&mut s, &HostReq::Kill { app: *id })?;
+    }
+    if to_kill.len() == 1 {
+        println!("tuiui kill-app: sent kill to app {}", to_kill[0]);
+    } else {
+        println!("tuiui kill-app: sent kill to {} app(s)", to_kill.len());
     }
     Ok(())
 }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -110,6 +110,12 @@ pub struct Flags {
     pub power_editing: bool,
     /// The logs-viewer window is focused; the client routes scroll/copy keys to it.
     pub logs_focused: bool,
+    /// The activity monitor is the focused window; the client routes
+    /// navigation / kill keys to it.
+    pub activity_focused: bool,
+    /// The activity monitor is showing a kill-confirm overlay; the client
+    /// forwards Enter / y to confirm and Esc / n to cancel.
+    pub activity_confirming: bool,
 }
 
 /// Per-user directory that holds the daemon socket. Created mode `0700` by the

--- a/src/ptyhost.rs
+++ b/src/ptyhost.rs
@@ -10,6 +10,7 @@ use alacritty_terminal::Term;
 use portable_pty::{native_pty_system, CommandBuilder, PtySize};
 use std::io::{Read, Write};
 use std::sync::{Arc, Mutex};
+use std::time::Instant;
 
 /// Default foreground/background used for cells that reference the terminal's
 /// "default" colors (and as a fallback for unresolved named colors).
@@ -74,6 +75,9 @@ pub struct AppInstance {
     clip: Arc<Mutex<Option<String>>>,
     cols: u16,
     rows: u16,
+    /// Wall-clock instant the child was spawned. Used by the activity monitor to
+    /// show how long each app has been running.
+    spawned_at: Instant,
 }
 
 impl AppInstance {
@@ -196,7 +200,7 @@ impl AppInstance {
             }
         });
 
-        Ok(AppInstance { term, master: pair.master, writer, child, graphics, bells, clip, cols, rows })
+        Ok(AppInstance { term, master: pair.master, writer, child, graphics, bells, clip, cols, rows, spawned_at: Instant::now() })
     }
 
     /// Bell rings since the last call (drained).
@@ -321,6 +325,17 @@ impl AppInstance {
     /// Whether the child process is still running.
     pub fn is_alive(&mut self) -> bool {
         matches!(self.child.try_wait(), Ok(None))
+    }
+
+    /// The child process's OS pid, if available. `None` when the platform can't
+    /// report one (or the child has already been reaped).
+    pub fn process_id(&self) -> Option<u32> {
+        self.child.process_id()
+    }
+
+    /// The wall-clock instant this instance was spawned.
+    pub fn spawned_at(&self) -> Instant {
+        self.spawned_at
     }
 
     /// Lock and return this app's captured Kitty-graphics state (placements +

--- a/src/session.rs
+++ b/src/session.rs
@@ -22,6 +22,7 @@ use crate::input::{route_mouse, MouseKind, Hit, Action};
 use crate::apphost::{AppHost, AppId, LocalAppHost};
 use crate::launcher::Launcher;
 use crate::settings::Settings;
+use crate::activity::Activity;
 use crate::store::{self, Store};
 use crate::window::WindowId;
 use crate::wm::{WindowManager, render_window};
@@ -63,6 +64,8 @@ enum WinContent {
     FileManager(crate::filemanager::DynFileManager),
     /// The native log viewer (tail of ~/tuiui-debug.log + clipboard copy).
     Logs(crate::logsview::LogsView),
+    /// The activity monitor — a live table of hosted apps with kill-app controls.
+    Activity(Activity),
 }
 
 impl WinContent {
@@ -74,6 +77,7 @@ impl WinContent {
             WinContent::ImageView(v) => v.render(w, h),
             WinContent::FileManager(f) => f.render(w, h),
             WinContent::Logs(l) => l.render(w, h),
+            WinContent::Activity(a) => a.render(w, h),
         }
     }
 }
@@ -222,6 +226,25 @@ pub enum ClientMsg {
     FileManagerCloseTab,
     /// File manager: focus the next tab.
     FileManagerNextTab,
+    /// Open the activity-monitor window (or focus it if already open).
+    OpenActivity,
+    /// Activity monitor: move selection up / down.
+    ActivityUp,
+    ActivityDown,
+    /// Activity monitor: request to kill the selected app (Enter / `k`).
+    /// Returns the requested kill via the in-app confirm overlay when the app
+    /// is alive, or kills immediately when it's already dead.
+    ActivityKill,
+    /// Activity monitor: confirm a pending kill (`Enter` / `y` from confirm).
+    ActivityConfirmKill,
+    /// Activity monitor: cancel a pending kill (`Esc` / `n` from confirm).
+    ActivityCancelKill,
+    /// Activity monitor: kill every row currently in the `dead` state.
+    ActivityKillDead,
+    /// Activity monitor: force a refresh of the row list (`r`).
+    ActivityRefresh,
+    /// Activity monitor: close the panel (`Esc` when no kill is pending).
+    ActivityClose,
     /// Toggle the keyboard-shortcut help overlay.
     ToggleHelp,
     /// Open an image file in a native image-viewer window.
@@ -357,6 +380,8 @@ pub struct SessionCore {
     apphost_outdated: bool,
     /// The logs-viewer window's id, if open.
     logs_win: Option<WindowId>,
+    /// The activity-monitor window's id, if open.
+    activity_win: Option<WindowId>,
     /// Text to put on the HOST terminal's clipboard (OSC 52), shipped to the
     /// client in the next frame: log copies and app OSC-52 stores.
     pending_clipboard: Option<String>,
@@ -462,6 +487,7 @@ impl SessionCore {
             compat_dialog: false,
             apphost_outdated: false,
             logs_win: None,
+            activity_win: None,
             pending_clipboard: None,
             titles: Vec::new(),
             app_keys: HashMap::new(),
@@ -1139,6 +1165,7 @@ impl SessionCore {
             AppEntry { name: "Settings".into(), command: "@settings".into(), args: vec![], category: Some("tuiui".into()), requires_cwd: None, cwd: None },
             AppEntry { name: "Files".into(), command: "@files".into(), args: vec![], category: Some("tuiui".into()), requires_cwd: None, cwd: None },
             AppEntry { name: "Logs".into(), command: "@logs".into(), args: vec![], category: Some("tuiui".into()), requires_cwd: None, cwd: None },
+            AppEntry { name: "Activity".into(), command: "@activity".into(), args: vec![], category: Some("tuiui".into()), requires_cwd: None, cwd: None },
         ];
         // Chat shortcuts for the gateway-style assistants when installed
         // (their chat UI is behind a flag/subcommand, so the bare-binary
@@ -1593,6 +1620,41 @@ impl SessionCore {
             ClientMsg::FileManagerNewTab => { if let Some(f) = self.focused_filemanager_mut() { f.new_tab(); } }
             ClientMsg::FileManagerCloseTab => { if let Some(f) = self.focused_filemanager_mut() { f.close_tab(); } }
             ClientMsg::FileManagerNextTab => { if let Some(f) = self.focused_filemanager_mut() { f.next_tab(); } }
+            ClientMsg::OpenActivity => self.open_activity(),
+            ClientMsg::ActivityUp => { if let Some(a) = self.focused_activity_mut() { a.move_up(); } }
+            ClientMsg::ActivityDown => { if let Some(a) = self.focused_activity_mut() { a.move_down(); } }
+            ClientMsg::ActivityKill => {
+                if let Some(a) = self.focused_activity_mut() {
+                    if let Some(app_id) = a.request_kill_selected() {
+                        self.apphost.kill(AppId(app_id));
+                    }
+                }
+            }
+            ClientMsg::ActivityConfirmKill => {
+                if let Some(a) = self.focused_activity_mut() {
+                    if let Some(app_id) = a.request_kill_selected() {
+                        self.apphost.kill(AppId(app_id));
+                    }
+                }
+            }
+            ClientMsg::ActivityCancelKill => {
+                if let Some(a) = self.focused_activity_mut() { a.cancel_kill(); }
+            }
+            ClientMsg::ActivityKillDead => {
+                if let Some(a) = self.focused_activity_mut() {
+                    for app_id in a.kill_dead() {
+                        self.apphost.kill(AppId(app_id));
+                    }
+                }
+            }
+            ClientMsg::ActivityRefresh => self.refresh_activity(),
+            ClientMsg::ActivityClose => {
+                if let Some(id) = self.activity_win.take() {
+                    if matches!(self.contents.get(&id), Some(WinContent::Activity(_))) {
+                        self.close(id);
+                    }
+                }
+            }
             ClientMsg::ToggleHelp => self.help_open = !self.help_open,
             ClientMsg::OpenImage(p) => self.open_image(p),
             ClientMsg::DirPickerUp => { if let Some(d) = self.dirpicker.as_mut() { d.move_up(); } }
@@ -2241,6 +2303,121 @@ impl SessionCore {
         });
     }
 
+    /// Open (or re-focus) the activity-monitor window, then immediately refresh
+    /// its row list so the user sees live data on first render.
+    fn open_activity(&mut self) {
+        if let Some(id) = self.activity_win {
+            if self.contents.contains_key(&id) {
+                self.wm.unminimize(id);
+                self.refresh_activity();
+                return;
+            }
+        }
+        let w = 84.min((self.w - 4).max(40));
+        let h = 22.min((self.h - 4).max(10));
+        let rect = Rect::new((self.w - w) / 2, 2, w, h);
+        let id = self.wm.add_window("Activity Monitor".into(), rect);
+        self.app_keys.insert(id, "Activity".into());
+        self.contents.insert(id, WinContent::Activity(Activity::new()));
+        self.titles.push((id, "Activity Monitor".into()));
+        self.activity_win = Some(id);
+        self.refresh_activity();
+    }
+
+    /// `true` when the focused window hosts the activity monitor.
+    pub fn focused_is_activity(&self) -> bool {
+        matches!(
+            self.wm.focused().and_then(|id| self.contents.get(&id)),
+            Some(WinContent::Activity(_))
+        )
+    }
+
+    /// `true` when the activity monitor's kill-confirm overlay is up; the
+    /// client uses this to route Enter / Esc / y / n to the panel.
+    pub fn activity_confirming(&self) -> bool {
+        self.focused_activity()
+            .map(|a| a.has_pending_kill())
+            .unwrap_or(false)
+    }
+
+    fn focused_activity_mut(&mut self) -> Option<&mut Activity> {
+        let id = self.wm.focused()?;
+        match self.contents.get_mut(&id)? {
+            WinContent::Activity(a) => Some(a),
+            _ => None,
+        }
+    }
+
+    fn focused_activity(&self) -> Option<&Activity> {
+        let id = self.wm.focused()?;
+        match self.contents.get(&id)? {
+            WinContent::Activity(a) => Some(a),
+            _ => None,
+        }
+    }
+
+    /// Rebuild the activity monitor's row list from the current `AppHost`.
+    /// Called every frame so the table stays live.
+    pub fn refresh_activity(&mut self) {
+        let entries: Vec<crate::apphost::AppListEntry> = self
+            .apphost
+            .list()
+            .into_iter()
+            .map(|id| {
+                let alive = self.apphost.is_alive(id);
+                let pid = self.apphost.pid(id);
+                let age_secs = self
+                    .apphost
+                    .spawn_time(id)
+                    .map(|t| t.elapsed().as_secs())
+                    .unwrap_or(0);
+                let (cols, rows) = self.apphost_dims(id);
+                let (cmd, args) = self.apphost_launch_cmd(id);
+                crate::apphost::AppListEntry {
+                    app: id.0,
+                    cmd,
+                    args,
+                    pid,
+                    cols,
+                    rows,
+                    age_secs,
+                    alive,
+                }
+            })
+            .collect();
+        if let Some(id) = self.activity_win {
+            if let Some(WinContent::Activity(a)) = self.contents.get_mut(&id) {
+                a.set_rows(entries);
+            }
+        }
+    }
+
+    /// Try to recover the launch command + args for `id` from the in-process
+    /// `LocalAppHost` (only available for that impl; `RemoteAppHost` returns
+    /// empty strings, which is fine — the panel just shows blanks).
+    fn apphost_launch_cmd(&self, id: AppId) -> (String, Vec<String>) {
+        // We don't have a trait-level accessor for the original cmd/args (and
+        // adding one would force the remote host to track them). Probe the
+        // concrete `LocalAppHost` by downcasting through Any.
+        use std::any::Any;
+        if let Some(local) = (&self.apphost as &dyn Any).downcast_ref::<crate::apphost::LocalAppHost>() {
+            local
+                .launch_cmd(id)
+                .map(|(c, a)| (c.to_string(), a.to_vec()))
+                .unwrap_or_default()
+        } else {
+            (String::new(), Vec::new())
+        }
+    }
+
+    fn apphost_dims(&self, id: AppId) -> (i32, i32) {
+        if let Some(snap) = self.apphost.snapshot(id) {
+            (snap.width(), snap.height())
+        } else {
+            (0, 0)
+        }
+    }
+
     /// The cwd of the focused file manager (for launching an app in-place).
     fn focused_fm_cwd(&self) -> Option<std::path::PathBuf> {
         match self.wm.focused().and_then(|id| self.contents.get(&id)) {
@@ -2376,6 +2553,7 @@ impl SessionCore {
                     self.open_remote_files(&name);
                 }
             }
+            "@activity" => self.open_activity(),
             "@image" => { if let Some(p) = e.args.first().cloned() { self.open_image(p); } }
             _ => self.launch_maybe_cwd(e.name, e.command, e.args, e.requires_cwd.unwrap_or(false), e.cwd),
         }
@@ -2802,6 +2980,7 @@ impl SessionCore {
                 let mut store_activate = false;
                 let mut settings_changed = false;
                 let mut fm_clicked = false;
+                let mut activity_kill: Option<u64> = None;
                 if let Some(cr) = cr {
                     match self.contents.get_mut(&id) {
                         Some(WinContent::Store(s)) => store_activate = s.handle_click(local, cr.w, cr.h),
@@ -2810,8 +2989,12 @@ impl SessionCore {
                         // single-select / toolbar-nav (Ctrl/Shift-select and
                         // double-click-to-open are keyboard-driven for v1).
                         Some(WinContent::FileManager(f)) => fm_clicked = f.handle_click(local, cr.w, cr.h, false, false),
+                        Some(WinContent::Activity(a)) => activity_kill = a.handle_click(local, cr.w),
                         _ => {}
                     }
+                }
+                if let Some(app_id) = activity_kill {
+                    self.apphost.kill(AppId(app_id));
                 }
                 if store_activate {
                     self.store_activate();
@@ -2956,6 +3139,9 @@ impl SessionCore {
         }
         if self.logs_win == Some(id) {
             self.logs_win = None;
+        }
+        if self.activity_win == Some(id) {
+            self.activity_win = None;
         }
         self.remote_fms.remove(&id);
         self.titles.retain(|(i, _)| *i != id);


### PR DESCRIPTION
## Summary

- **In-app Activity Monitor panel** opened via `Ctrl+Space A` or `@activity` in the launcher. Shows a live, auto-refreshing table of every app the apphost is hosting, with kill-app controls. `↑/↓` select, `Enter`/`k` kill (live rows get a confirm overlay, dead rows kill immediately), `K` kill all dead, `r` refresh, `Esc` close. Click the red `kill` glyph to kill.
- **`tuiui ps`** CLI: fixed-width table of hosted apps (APPID, PID, CMD, COLS×ROWS, AGE, STATE). Works from any TTY or SSH session.
- **`tuiui kill-app <id|all>`** CLI: kill one app (by id) or every dead app.

## Plumbing

- New `HostReq::ListApps` / `HostEvt::AppList` protocol message.
- `AppInstance::process_id()` and `spawned_at()` accessors.
- `AppHost` trait gains `pid()` and `spawn_time()` (None defaults for `RemoteAppHost`; `LocalAppHost` forwards).
- `LocalAppHost` tracks per-app `cmd`/`args` for display.
- `WinContent::Activity(Activity)` mirrors `Store`/`Settings`/`FileManager`.
- `Flags::{activity_focused, activity_confirming}` so the client routes keys correctly.
- The session rebuilds the activity row list every tick from the in-process `AppHost`; the in-app panel never crosses a process boundary.

## Notes

- The apphost is single-frontend, so the CLI tools queue at the listener while the daemon is attached (same model as the existing `tuiui kill`). The in-app panel is the recommended live path.
- Leader binding is `Ctrl+Space A` (uppercase) because lowercase `a` is already the app menu. Updated the help overlay and README accordingly.

## Tests

- 6 new activity widget unit tests (empty panel, selection clamping, kill confirm flow, age formatting).
- 1 new end-to-end `ListApps` round-trip test in `apphost::remote` over a loopback apphost socket.
- All existing tests pass; `cargo clippy --all-targets` clean; `cargo build --release` clean.