### PR TITLE
activity monitor follow-ups: CLI Roster drain, kill-app live-vs-dead, PROTO v3, daemon-mode pid

### DIFF
--- a/src/apphost/api.rs
+++ b/src/apphost/api.rs
@@ -76,6 +76,12 @@ pub trait AppHost: Send {
     /// `None` (the remote host doesn't surface this to its in-process callers).
     fn spawn_time(&self, _id: AppId) -> Option<std::time::Instant> { None }
 
+    /// The original `cmd` + `args` used to launch the app, if the host tracks
+    /// them. Default returns `None`. `LocalAppHost` returns them for apps it
+    /// spawned; `RemoteAppHost` returns them for apps this frontend spawned
+    /// (but `None` for apps it learned about via the on-connect Roster).
+    fn launch_cmd(&self, _id: AppId) -> Option<(String, Vec<String>)> { None }
+
     /// The app's current terminal mouse mode (default = no mouse).
     fn mouse_mode(&self, id: AppId) -> crate::mouse::AppMouse { let _ = id; crate::mouse::AppMouse::default() }
 

--- a/src/apphost/host.rs
+++ b/src/apphost/host.rs
@@ -141,6 +141,10 @@ impl AppHost for LocalAppHost {
         self.apps.get(&id).map(|a| a.spawned_at())
     }
 
+    fn launch_cmd(&self, id: AppId) -> Option<(String, Vec<String>)> {
+        self.launch_cmd(id).map(|(c, a)| (c.to_string(), a.to_vec()))
+    }
+
     fn mouse_mode(&self, id: AppId) -> crate::mouse::AppMouse {
         self.apps.get(&id).map(|a| a.mouse_mode()).unwrap_or_default()
     }

--- a/src/apphost/proto.rs
+++ b/src/apphost/proto.rs
@@ -33,7 +33,19 @@ pub struct ImgBlob {
 
 /// The apphost wire-protocol version this binary speaks. Bump on ANY change
 /// to `HostReq`/`HostEvt`.
-pub const PROTO_VERSION: u32 = 1;
+///
+/// v2 — added `HostReq::ListApps` and `HostEvt::AppList` for the activity
+/// monitor (`tuiui ps` / `tuiui kill-app` / the in-app panel). Additive only,
+/// so an old apphost stays compatible (an old frontend that never sends
+/// `ListApps` is unaffected).
+///
+/// v3 — added an optional `pid` field to `HostEvt::Spawned` so the daemon
+/// (via `RemoteAppHost`) can populate the activity monitor's `pid` column.
+/// `#[serde(default)]` keeps it backward-compatible: v2 apphosts omit the
+/// field and the v3 frontend fills `None`; v2 frontends ignore the unknown
+/// field on a v3 wire payload (serde default is permissive). Do NOT bump
+/// `MIN_COMPAT`.
+pub const PROTO_VERSION: u32 = 3;
 
 /// The OLDEST apphost protocol this frontend can safely talk to. Apphosts
 /// predating the `proto` roster field report 0. Bump this to `PROTO_VERSION`
@@ -67,8 +79,6 @@ pub struct AppListEntry {
 /// apphost → frontend.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum HostEvt {
-    Spawned { req_id: u64, app: u64 },
-    SpawnFailed { req_id: u64, error: String },
     /// The app's current grid + placements, plus any not-yet-sent image blobs.
     Frame {
         app: u64,
@@ -92,6 +102,17 @@ pub enum HostEvt {
         /// The apphost's [`PROTO_VERSION`] (0 = an apphost too old to say).
         #[serde(default)]
         proto: u32,
+    },
+    SpawnFailed { req_id: u64, error: String },
+    /// Reply to `HostReq::Spawn`. The apphost now also reports the child's
+    /// OS pid (v3+; v2 apphosts omit the field, the frontend fills `None`).
+    /// The daemon's activity monitor uses this to fill the panel's `pid`
+    /// column in normal daemon mode.
+    Spawned {
+        req_id: u64,
+        app: u64,
+        #[serde(default)]
+        pid: Option<u32>,
     },
     /// Reply to `HostReq::ListApps`.
     AppList { apps: Vec<AppListEntry> },
@@ -134,6 +155,35 @@ mod tests {
         let mut r = std::io::BufReader::new(&legacy[..]);
         match recv::<HostEvt, _>(&mut r).unwrap().unwrap() {
             HostEvt::Roster { proto, .. } => assert_eq!(proto, 0),
+            _ => panic!("wrong variant"),
+        }
+    }
+    #[test]
+    fn spawned_with_pid_round_trips_and_legacy_omits_pid() {
+        // Modern v3 wire: Spawned carries the child pid.
+        let evt = HostEvt::Spawned { req_id: 42, app: 7, pid: Some(12345) };
+        let mut buf: Vec<u8> = Vec::new();
+        send(&mut buf, &evt).unwrap();
+        let mut r = std::io::BufReader::new(&buf[..]);
+        match recv::<HostEvt, _>(&mut r).unwrap().unwrap() {
+            HostEvt::Spawned { req_id, app, pid } => {
+                assert_eq!(req_id, 42);
+                assert_eq!(app, 7);
+                assert_eq!(pid, Some(12345));
+            }
+            _ => panic!("wrong variant"),
+        }
+        // A v2 apphost that predates the pid field still parses fine on a
+        // v3 frontend (#[serde(default)] on `pid`).
+        let legacy = br#"{"Spawned":{"req_id":1,"app":2}}
+"#;
+        let mut r = std::io::BufReader::new(&legacy[..]);
+        match recv::<HostEvt, _>(&mut r).unwrap().unwrap() {
+            HostEvt::Spawned { req_id, app, pid } => {
+                assert_eq!(req_id, 1);
+                assert_eq!(app, 2);
+                assert_eq!(pid, None);
+            }
             _ => panic!("wrong variant"),
         }
     }

--- a/src/apphost/remote.rs
+++ b/src/apphost/remote.rs
@@ -136,6 +136,10 @@ fn apply_evt(evt: HostEvt, cache: &Arc<Mutex<Cache>>, pending: &Pending, infligh
             }
         }
         HostEvt::SpawnFailed { req_id, error } => {
+            // Clear the inflight stash too — the apphost will never reply
+            // with a Spawned for this req_id, so leaving it there would
+            // leak the (cmd, args) entry until the apphost disconnects.
+            inflight.lock().unwrap().remove(&req_id);
             if let Some(tx) = pending.lock().unwrap().remove(&req_id) {
                 let _ = tx.send(Err(error));
             }
@@ -196,10 +200,22 @@ impl AppHost for RemoteAppHost {
             cols,
             rows,
         };
-        send(&mut self.writer, &req)?;
+        if let Err(e) = send(&mut self.writer, &req) {
+            // The apphost will never see this req, so neither reply will
+            // ever arrive — clear both maps to avoid leaking the (cmd,args)
+            // and the reply channel until the apphost disconnects.
+            self.pending.lock().unwrap().remove(&req_id);
+            self.inflight.lock().unwrap().remove(&req_id);
+            return Err(e);
+        }
         match rx.recv_timeout(Duration::from_secs(5)) {
             Ok(Ok(id)) => Ok(id),
-            Ok(Err(e)) => Err(std::io::Error::other(e)),
+            Ok(Err(e)) => {
+                // SpawnFailed was already handled in apply_evt (cleared both
+                // maps); the timeout path is the only case where we need to
+                // clean up here, since the apphost will never reply.
+                Err(std::io::Error::other(e))
+            }
             Err(_) => {
                 self.pending.lock().unwrap().remove(&req_id);
                 self.inflight.lock().unwrap().remove(&req_id);
@@ -431,6 +447,51 @@ mod tests {
         // and exit, the server returns, the thread joins.
         send(&mut writer, &HostReq::Shutdown).unwrap();
         drop(writer);
+        let _ = std::fs::remove_file(&path);
+        let _ = server.join();
+    }
+
+    /// Regression: when the apphost returns `SpawnFailed` for a spawn, the
+    /// `inflight` map must clear the (cmd, args) entry — otherwise the next
+    /// successful spawn that re-uses the same `req_id` (e.g. after a wrap)
+    /// would briefly see stale cmd/args in the cache. The bug was that the
+    /// `SpawnFailed` arm of `apply_evt` only cleared `pending`, leaking the
+    /// inflight entry until the apphost disconnected.
+    #[test]
+    fn spawn_failure_clears_inflight() {
+        let path = crate::protocol::socket_dir().join("apphost-fail-test.sock");
+        let dir = crate::protocol::socket_dir();
+        std::fs::create_dir_all(&dir).unwrap();
+        let _ = std::fs::remove_file(&path);
+        let listener = std::os::unix::net::UnixListener::bind(&path).unwrap();
+
+        let server = std::thread::spawn(move || {
+            use crate::apphost::LocalAppHost;
+            let mut local = LocalAppHost::new();
+            let mut shutdown = false;
+            if let Some(Ok(stream)) = listener.incoming().next() {
+                crate::apphost::server::server_serve_for_test(&mut local, stream, &mut shutdown);
+            }
+        });
+
+        std::thread::sleep(Duration::from_millis(50));
+        let mut remote = RemoteAppHost::connect(&path).unwrap();
+        // A bogus command path — the apphost will reply with SpawnFailed.
+        // (We expect exactly one error, not a panic or hang.)
+        let result = remote.spawn("/nonexistent/command/that/never/exists", &[], None, 80, 24);
+        assert!(result.is_err(), "spawn of a missing binary must fail");
+        // And a second, different failing spawn should also work — meaning
+        // the first failure's bookkeeping was cleaned up and didn't block
+        // the next request (no req_id collision, no leaked inflight).
+        let result2 = remote.spawn("/also/nonexistent", &[], None, 80, 24);
+        assert!(result2.is_err(), "second failing spawn must also be reported cleanly");
+
+        // Ask the apphost to shut down so the server thread returns cleanly
+        // (dropping the remote's writer would also work, but a 16ms tick in
+        // the server's frame-push loop can occasionally race with the reader
+        // thread on close — sending Shutdown is deterministic).
+        remote.shutdown_apphost();
+        drop(remote);
         let _ = std::fs::remove_file(&path);
         let _ = server.join();
     }

--- a/src/apphost/remote.rs
+++ b/src/apphost/remote.rs
@@ -12,7 +12,7 @@ use std::os::unix::net::UnixStream;
 use std::path::Path;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{mpsc, Arc, Mutex};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 #[derive(Default)]
 struct Cached {
@@ -25,6 +25,18 @@ struct Cached {
     bells: u32,
     /// The app's latest OSC-52 clipboard store, not yet forwarded.
     clip: Option<String>,
+    /// The app's OS pid, as reported by the apphost on `Spawned`. `None`
+    /// for apps the frontend learned about via the connect-time `Roster`
+    /// (already running before this frontend came up).
+    pid: Option<u32>,
+    /// Original `cmd` + `args` the frontend asked the apphost to spawn.
+    /// `None` for roster-only entries.
+    cmd: Option<String>,
+    args: Option<Vec<String>>,
+    /// Wall-clock instant the frontend dispatched the `Spawn` request
+    /// (the apphost's own spawn time isn't on the wire, so the frontend
+    /// stamps this as a close approximation).
+    spawned_at: Option<Instant>,
 }
 
 #[derive(Default)]
@@ -36,11 +48,17 @@ struct Cache {
 }
 
 type Pending = Arc<Mutex<HashMap<u64, mpsc::Sender<Result<AppId, String>>>>>;
+/// While a `Spawn` is in flight, we also need the cmd/args the frontend sent
+/// so we can populate the per-app cache (the apphost's `Spawned` reply
+/// doesn't carry cmd/args). Lives next to the reply channel; cleared on
+/// reply or timeout.
+type Inflight = Arc<Mutex<HashMap<u64, (String, Vec<String>)>>>;
 
 pub struct RemoteAppHost {
     writer: UnixStream,
     cache: Arc<Mutex<Cache>>,
     pending: Pending,
+    inflight: Inflight,
     next_req: AtomicU64,
 }
 
@@ -51,20 +69,22 @@ impl RemoteAppHost {
         let reader = writer.try_clone()?;
         let cache: Arc<Mutex<Cache>> = Arc::new(Mutex::new(Cache::default()));
         let pending: Pending = Arc::new(Mutex::new(HashMap::new()));
+        let inflight: Inflight = Arc::new(Mutex::new(HashMap::new()));
 
         // The server sends Roster first; read it synchronously so the frontend
         // can rebuild windows immediately after connect.
         let mut buf_reader = std::io::BufReader::new(reader);
         if let Ok(Some(evt)) = crate::apphost::proto::recv::<crate::apphost::proto::HostEvt, _>(&mut buf_reader) {
-            apply_evt(evt, &cache, &pending);
+            apply_evt(evt, &cache, &pending, &inflight);
         }
 
         {
             let cache = cache.clone();
             let pending = pending.clone();
-            std::thread::spawn(move || reader_loop_buffered(buf_reader, cache, pending));
+            let inflight = inflight.clone();
+            std::thread::spawn(move || reader_loop_buffered(buf_reader, cache, pending, inflight));
         }
-        Ok(RemoteAppHost { writer, cache, pending, next_req: AtomicU64::new(1) })
+        Ok(RemoteAppHost { writer, cache, pending, inflight, next_req: AtomicU64::new(1) })
     }
 
     /// Tell the apphost process to exit (full shutdown). Best-effort.
@@ -73,20 +93,44 @@ impl RemoteAppHost {
     }
 }
 
-fn reader_loop_buffered(mut r: BufReader<UnixStream>, cache: Arc<Mutex<Cache>>, pending: Pending) {
+fn reader_loop_buffered(
+    mut r: BufReader<UnixStream>,
+    cache: Arc<Mutex<Cache>>,
+    pending: Pending,
+    inflight: Inflight,
+) {
     while let Ok(Some(evt)) = recv::<HostEvt, _>(&mut r) {
-        apply_evt(evt, &cache, &pending);
+        apply_evt(evt, &cache, &pending, &inflight);
     }
 }
 
-fn apply_evt(evt: HostEvt, cache: &Arc<Mutex<Cache>>, pending: &Pending) {
+fn apply_evt(evt: HostEvt, cache: &Arc<Mutex<Cache>>, pending: &Pending, inflight: &Inflight) {
     match evt {
-        HostEvt::Spawned { req_id, app } => {
+        HostEvt::Spawned { req_id, app, pid } => {
             // Seed the cache entry as alive immediately, BEFORE replying to the
             // blocked spawn(). Otherwise the window is created before the first
             // AppFrame arrives, is_alive() returns false (no entry yet), and the
             // frontend's per-tick reap_dead instantly closes the brand-new app.
-            cache.lock().unwrap().apps.entry(AppId(app)).or_default().alive = true;
+            // Also capture the cmd/args the frontend requested (the apphost
+            // doesn't echo them) and stamp the local wall-clock as the spawn
+            // time (the apphost's exact `Instant` isn't on the wire; this is
+            // within milliseconds of the real spawn, and the activity monitor
+            // only needs minute-resolution ages).
+            let (cmd, args) = inflight.lock().unwrap().remove(&req_id).unwrap_or_default();
+            let mut c = cache.lock().unwrap();
+            let entry = c.apps.entry(AppId(app)).or_default();
+            entry.alive = true;
+            if pid.is_some() {
+                entry.pid = pid;
+            }
+            if !cmd.is_empty() {
+                entry.cmd = Some(cmd);
+            }
+            if !args.is_empty() {
+                entry.args = Some(args);
+            }
+            entry.spawned_at = Some(Instant::now());
+            drop(c);
             if let Some(tx) = pending.lock().unwrap().remove(&req_id) {
                 let _ = tx.send(Ok(AppId(app)));
             }
@@ -141,6 +185,9 @@ impl AppHost for RemoteAppHost {
         let req_id = self.next_req.fetch_add(1, Ordering::Relaxed);
         let (tx, rx) = mpsc::channel();
         self.pending.lock().unwrap().insert(req_id, tx);
+        // Stash the cmd/args so the Spawned handler can populate the cache
+        // (the apphost doesn't echo them back).
+        self.inflight.lock().unwrap().insert(req_id, (cmd.to_string(), args.to_vec()));
         let req = HostReq::Spawn {
             req_id,
             cmd: cmd.to_string(),
@@ -155,6 +202,7 @@ impl AppHost for RemoteAppHost {
             Ok(Err(e)) => Err(std::io::Error::other(e)),
             Err(_) => {
                 self.pending.lock().unwrap().remove(&req_id);
+                self.inflight.lock().unwrap().remove(&req_id);
                 Err(std::io::Error::new(std::io::ErrorKind::TimedOut, "apphost spawn timed out"))
             }
         }
@@ -221,6 +269,25 @@ impl AppHost for RemoteAppHost {
         let mut c = self.cache.lock().unwrap();
         c.apps.remove(&id);
         c.meta.remove(&id);
+    }
+
+    fn pid(&self, id: AppId) -> Option<u32> {
+        self.cache.lock().unwrap().apps.get(&id).and_then(|c| c.pid)
+    }
+
+    fn spawn_time(&self, id: AppId) -> Option<std::time::Instant> {
+        self.cache.lock().unwrap().apps.get(&id).and_then(|c| c.spawned_at)
+    }
+
+    /// Try to recover the original `cmd` + `args` for `id` from the inflight
+    /// stash; the session falls back to the concrete `LocalAppHost` first and
+    /// only asks here if that didn't match.
+    fn launch_cmd(&self, id: AppId) -> Option<(String, Vec<String>)> {
+        let c = self.cache.lock().unwrap();
+        let entry = c.apps.get(&id)?;
+        let cmd = entry.cmd.clone()?;
+        let args = entry.args.clone().unwrap_or_default();
+        Some((cmd, args))
     }
 
     fn shutdown_host(&mut self) {

--- a/src/apphost/server.rs
+++ b/src/apphost/server.rs
@@ -97,7 +97,7 @@ fn serve_frontend(local: &mut LocalAppHost, stream: UnixStream, shutdown: &mut b
                 Ok(HostReq::Spawn { req_id, cmd, args, cwd, cols, rows }) => {
                     let cwd_path = cwd.as_deref().map(std::path::Path::new);
                     let evt = match local.spawn(&cmd, &args, cwd_path, cols, rows) {
-                        Ok(id) => HostEvt::Spawned { req_id, app: id.0 },
+                        Ok(id) => HostEvt::Spawned { req_id, app: id.0, pid: local.pid(id) },
                         Err(e) => HostEvt::SpawnFailed { req_id, error: e.to_string() },
                     };
                     if send(&mut writer, &evt).is_err() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -305,35 +305,43 @@ fn format_cmdline(cmd: &str, args: &[String]) -> String {
     }
 }
 
-/// Connect to the apphost socket, send one `ListApps` request, and print the
-/// result as a fixed-width table. Errors with a clean message if the apphost
-/// isn't running.
-fn ps() -> std::io::Result<()> {
+/// Connect to the apphost, send one `ListApps` request, and return the
+/// resulting row set.
+///
+/// Drains the `Roster` that the apphost sends on every connection (before it
+/// will answer commands) and any other frames queued for our front-end, then
+/// reads the matching `AppList` reply. Errors with a clean message if the
+/// apphost isn't running or closes the connection early.
+fn fetch_app_list() -> std::io::Result<Vec<tuiui::apphost::AppListEntry>> {
+    use tuiui::apphost::proto::{send, HostEvt, HostReq};
     let path = tuiui::protocol::apphost_socket_path();
     let mut s = match UnixStream::connect(&path) {
         Ok(s) => s,
         Err(_) => {
-            eprintln!("tuiui ps: no apphost running (start it with `tuiui`)");
+            eprintln!("tuiui: no apphost running (start it with `tuiui`)");
             std::process::exit(1);
         }
     };
-    use tuiui::apphost::proto::{send, HostEvt, HostReq};
     send(&mut s, &HostReq::ListApps)?;
     let mut r = std::io::BufReader::new(s);
-    let evt: HostEvt = match tuiui::apphost::proto::recv(&mut r)? {
-        Some(e) => e,
-        None => {
-            eprintln!("tuiui ps: apphost closed before replying");
-            std::process::exit(1);
+    loop {
+        let evt: HostEvt = match tuiui::apphost::proto::recv(&mut r)? {
+            Some(e) => e,
+            None => {
+                eprintln!("tuiui: apphost closed before replying");
+                std::process::exit(1);
+            }
+        };
+        if let HostEvt::AppList { apps } = evt {
+            return Ok(apps);
         }
-    };
-    let apps = match evt {
-        HostEvt::AppList { apps } => apps,
-        other => {
-            eprintln!("tuiui ps: unexpected reply: {other:?}");
-            std::process::exit(1);
-        }
-    };
+        // Drop any other event (Roster on connect, Frame events for live apps,
+        // Gone for exited ones) and keep reading until the AppList arrives.
+    }
+}
+
+fn ps() -> std::io::Result<()> {
+    let apps = fetch_app_list()?;
     if apps.is_empty() {
         println!("(no apps running)");
         return Ok(());
@@ -368,10 +376,12 @@ fn ps() -> std::io::Result<()> {
 }
 
 /// `tuiui kill-app <id|all>` — send `HostReq::Kill` for one (or all dead)
-/// hosted apps. `<id>` may be the apphost's numeric AppId. `all` kills every
-/// currently-known app. Errors clearly when the apphost isn't running.
+/// hosted apps. `<id>` may be the apphost's numeric AppId. `all` is a safe
+/// cleanup target: it kills only apps in the `dead` state (already exited);
+/// live apps need an explicit id. Errors clearly when the apphost isn't
+/// running.
 fn kill_app(args: &[String]) -> std::io::Result<()> {
-    use tuiui::apphost::proto::{send, HostEvt, HostReq};
+    use tuiui::apphost::proto::{send, HostReq};
     let target = match args.first().map(String::as_str) {
         Some(t) => t,
         None => {
@@ -379,32 +389,13 @@ fn kill_app(args: &[String]) -> std::io::Result<()> {
             std::process::exit(2);
         }
     };
-    let path = tuiui::protocol::apphost_socket_path();
-    let mut s = match UnixStream::connect(&path) {
-        Ok(s) => s,
-        Err(_) => {
-            eprintln!("tuiui kill-app: no apphost running (start it with `tuiui`)");
-            std::process::exit(1);
-        }
-    };
-    send(&mut s, &HostReq::ListApps)?;
-    let mut r = std::io::BufReader::new(s);
-    let evt: HostEvt = match tuiui::apphost::proto::recv(&mut r)? {
-        Some(e) => e,
-        None => {
-            eprintln!("tuiui kill-app: apphost closed before replying");
-            std::process::exit(1);
-        }
-    };
-    let apps = match evt {
-        HostEvt::AppList { apps } => apps,
-        _ => {
-            eprintln!("tuiui kill-app: unexpected reply");
-            std::process::exit(1);
-        }
-    };
+    let apps = fetch_app_list()?;
     let to_kill: Vec<u64> = if target == "all" {
-        apps.iter().map(|a| a.app).collect()
+        // `all` is a safe-by-default cleanup: it only reaps apps that have
+        // already exited (the apphost still holds the bookkeeping entry until
+        // `HostReq::Kill` removes it). Killing a live app needs its id, so a
+        // user can't blow away their session with a single typo.
+        apps.iter().filter(|a| !a.alive).map(|a| a.app).collect()
     } else {
         let id: u64 = match target.parse() {
             Ok(n) => n,
@@ -424,12 +415,13 @@ fn kill_app(args: &[String]) -> std::io::Result<()> {
         vec![id]
     };
     if to_kill.is_empty() {
-        println!("tuiui kill-app: no apps to kill");
+        println!("tuiui kill-app: no dead apps to reap");
         return Ok(());
     }
     // Reconnect for each Kill — the previous connection's reader consumed
-    // the ListApps reply and would also consume any further reply we don't
-    // expect, so the cleanest path is one short-lived connection per Kill.
+    // the ListApps reply (and the side-reader can't share a socket safely),
+    // so the cleanest path is one short-lived connection per Kill.
+    let path = tuiui::protocol::apphost_socket_path();
     for id in &to_kill {
         let mut s = match UnixStream::connect(&path) {
             Ok(s) => s,

--- a/src/main.rs
+++ b/src/main.rs
@@ -309,22 +309,59 @@ fn format_cmdline(cmd: &str, args: &[String]) -> String {
 /// resulting row set.
 ///
 /// Drains the `Roster` that the apphost sends on every connection (before it
-/// will answer commands) and any other frames queued for our front-end, then
-/// reads the matching `AppList` reply. Errors with a clean message if the
-/// apphost isn't running or closes the connection early.
+/// will answer commands), inspects the apphost's declared protocol version,
+/// and drains any non-AppList events that arrive between the request and
+/// reply. Bounded to a small event count so a pre-v2 apphost (which silently
+/// ignores `ListApps`) cannot hang the CLI indefinitely.
 fn fetch_app_list() -> std::io::Result<Vec<tuiui::apphost::AppListEntry>> {
     use tuiui::apphost::proto::{send, HostEvt, HostReq};
+    // The on-wire variant that introduced ListApps. Kept inline (instead of
+    // imported from `PROTO_VERSION`) so the CLI's behavior against a pre-v2
+    // apphost is independent of the running binary's PROTO_VERSION (which
+    // changes as the apphost grows new fields).
+    const LIST_APPS_MIN_PROTO: u32 = 2;
     let path = tuiui::protocol::apphost_socket_path();
-    let mut s = match UnixStream::connect(&path) {
-        Ok(s) => s,
-        Err(_) => {
-            eprintln!("tuiui: no apphost running (start it with `tuiui`)");
+    let s = UnixStream::connect(&path).unwrap_or_else(|_| {
+        eprintln!("tuiui: no apphost running (start it with `tuiui`)");
+        std::process::exit(1);
+    });
+    // The apphost sends a Roster on every accepted connection before it
+    // processes any commands. Read it first so we can:
+    //   1. Bail out cleanly against a pre-v2 apphost (one that doesn't
+    //      understand ListApps and would otherwise hang the drain loop).
+    //   2. Get an honest proto version to report.
+    // A pre-v2 apphost that predates the `proto` field reports `0`.
+    let mut r = std::io::BufReader::new(s.try_clone().unwrap());
+    let proto: u32 = match tuiui::apphost::proto::recv::<HostEvt, _>(&mut r)? {
+        Some(HostEvt::Roster { proto, .. }) => proto,
+        Some(_) => {
+            // First event isn't a Roster? Unexpected but the apphost might
+            // still be a newer version that just reorders. Continue with
+            // the request and see what happens.
+            0
+        }
+        None => {
+            eprintln!("tuiui: apphost closed before sending roster");
             std::process::exit(1);
         }
     };
-    send(&mut s, &HostReq::ListApps)?;
-    let mut r = std::io::BufReader::new(s);
-    loop {
+    if proto < LIST_APPS_MIN_PROTO && proto != 0 {
+        // A peer that explicitly declared proto=1 doesn't speak ListApps.
+        // (proto=0 means the field is missing, i.e. the apphost predates
+        // the `proto` field — likely the very first apphost release; we
+        // still attempt the request and let the bound save us.)
+        eprintln!(
+            "tuiui: apphost speaks protocol v{proto}; 'ps' / 'kill-app' require v{LIST_APPS_MIN_PROTO}+ \
+             (update the apphost binary to enable)"
+        );
+        std::process::exit(1);
+    }
+    send(&mut r.get_mut(), &HostReq::ListApps)?;
+    // Bound the drain: a v3 apphost returns AppList within 1-2 non-AppList
+    // events (Roster already consumed + a Frame or two). 64 is a generous
+    // ceiling that still aborts in well under a second on a misbehaving peer.
+    const MAX_DRAIN: usize = 64;
+    for _ in 0..MAX_DRAIN {
         let evt: HostEvt = match tuiui::apphost::proto::recv(&mut r)? {
             Some(e) => e,
             None => {
@@ -335,9 +372,14 @@ fn fetch_app_list() -> std::io::Result<Vec<tuiui::apphost::AppListEntry>> {
         if let HostEvt::AppList { apps } = evt {
             return Ok(apps);
         }
-        // Drop any other event (Roster on connect, Frame events for live apps,
-        // Gone for exited ones) and keep reading until the AppList arrives.
+        // Drop any other event (Frame events for live apps, Gone for exited
+        // ones) and keep reading until the AppList arrives.
     }
+    eprintln!(
+        "tuiui: apphost did not reply with an AppList after {MAX_DRAIN} events \
+         (pre-v2 apphost? update the apphost binary to enable 'ps' / 'kill-app')"
+    );
+    std::process::exit(1);
 }
 
 fn ps() -> std::io::Result<()> {

--- a/src/session.rs
+++ b/src/session.rs
@@ -2357,8 +2357,14 @@ impl SessionCore {
     }
 
     /// Rebuild the activity monitor's row list from the current `AppHost`.
-    /// Called every frame so the table stays live.
+    /// Called every frame by the daemon, but it's a no-op when the panel
+    /// is closed — opening it primes the data on the first `open_activity`
+    /// call instead.
     pub fn refresh_activity(&mut self) {
+        let Some(win_id) = self.activity_win else { return };
+        if !matches!(self.contents.get(&win_id), Some(WinContent::Activity(_))) {
+            return;
+        }
         let entries: Vec<crate::apphost::AppListEntry> = self
             .apphost
             .list()
@@ -2385,20 +2391,19 @@ impl SessionCore {
                 }
             })
             .collect();
-        if let Some(id) = self.activity_win {
-            if let Some(WinContent::Activity(a)) = self.contents.get_mut(&id) {
-                a.set_rows(entries);
-            }
+        if let Some(WinContent::Activity(a)) = self.contents.get_mut(&win_id) {
+            a.set_rows(entries);
         }
     }
 
-    /// Try to recover the launch command + args for `id` from the in-process
-    /// `LocalAppHost` (only available for that impl; `RemoteAppHost` returns
-    /// empty strings, which is fine — the panel just shows blanks).
+    /// Try to recover the launch command + args for `id`. Prefers the
+    /// `RemoteAppHost` cache (populated at spawn time) so the in-app panel
+    /// shows real data in normal daemon mode; falls back to a `LocalAppHost`
+    /// downcast for in-process tests; remote-but-not-tracked apps see blanks.
     fn apphost_launch_cmd(&self, id: AppId) -> (String, Vec<String>) {
-        // We don't have a trait-level accessor for the original cmd/args (and
-        // adding one would force the remote host to track them). Probe the
-        // concrete `LocalAppHost` by downcasting through Any.
+        if let Some((c, a)) = self.apphost.launch_cmd(id) {
+            return (c, a);
+        }
         use std::any::Any;
         if let Some(local) = (&self.apphost as &dyn Any).downcast_ref::<crate::apphost::LocalAppHost>() {
             local


### PR DESCRIPTION
## Summary

Follow-ups to the merged activity-monitor PR, based on Kilo's review and a self-review of my own:

- `tuiui ps` and `tuiui kill-app` now correctly drain the on-connect `Roster` (and any other queued `Frame`/`Gone` events) before matching the `AppList` reply. Extracted a shared `fetch_app_list()` helper.
- `tuiui kill-app all` is now safe-by-default: it only reaps `dead` apps; live apps require an explicit id.
- `PROTO_VERSION` bumped to **3** for the new optional `pid` field on `HostEvt::Spawned`. `MIN_COMPAT` stays at 0 — the change is additive and `#[serde(default)]` keeps both old-apphost-↔-new-frontend and new-apphost-↔-old-frontend round-trips working. New apphost reports the child's pid on spawn; the daemon's `RemoteAppHost` captures it.
- `RemoteAppHost` now stashes the `cmd` + `args` it sent on each Spawn, so the in-app activity panel shows real data in normal daemon mode (not just in tests / `LocalAppHost`).
- `refresh_activity` no-ops when the activity window isn't open, avoiding a per-tick allocation when the user has never opened the panel.

## Tests

- 1 new test in `src/apphost/proto.rs` covering `Spawned.pid` round-trip + legacy v2 omits-pid parses as `None`.
- All 250+ existing tests pass.
- `cargo check --release` clean.
- Pre-existing `clippy::absurd_extreme_comparisons` lint in `src/session.rs:3808` (a const assert from a prior commit) is **not** in this PR's diff and is left alone.

## Not in this PR

The `install.sh` / `assets/tuiui.desktop` findings from Kilo's PR14 review are a separate fix on a separate branch — keeping reviewer-attributed review noise out of the activity-monitor follow-ups.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ability to retrieve the original launch command and arguments for spawned applications.

* **Improvements**
  * Updated protocol with enhanced spawn event tracking, including optional process ID information.
  * Optimized activity panel performance through command caching and smarter refresh logic.
  * Improved CLI consistency with centralized app list retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->