### PR TITLE
Robustness fixes: updater branch validation, control-lock, remote-FM timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ carry user-visible feature work and the occasional breaking config change.
   the rescue hatch for a mis-placed window).
 
 ### Fixed
+- **Updater robustness** (from a code review): an invalid or typo'd
+  `update_branch` in `config.toml` now falls back to `main` instead of
+  producing a malformed update command or check URL.
+- **Control-socket resilience**: the daemon no longer holds the control-message
+  lock across `apply` (which could block `tuiui launch/tile/theme/msg` from the
+  CLI/assistant), and recovers a poisoned lock so one panic can't wedge the
+  control path.
+- **Remote file browser**: tighter navigation timeouts (ssh ConnectTimeout 3s,
+  directory list/home 5s) so an unreachable saved system is a brief hitch
+  rather than a multi-second freeze (a full off-render-loop fix is tracked).
 - **Add Remote on Debian**: three failure modes fixed — Linux release
   binaries are now built on Ubuntu 22.04 (glibc 2.35) so they run on
   Debian 12 instead of dying with "GLIBC_2.39 not found"; the installer and

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -324,7 +324,15 @@ fn serve_client(
 /// If a control message has arrived, apply it to `core` (setting its
 /// shutdown/reload flag, which the loops already act on) and return `true`.
 fn apply_ctl(ctl: &Arc<AtomicU8>, queue: &CtlQueue, core: &mut SessionCore) -> bool {
-    for msg in queue.lock().unwrap().drain(..) {
+    // Drain under the lock into a local batch, then release it before applying:
+    // `core.apply` can be slow (spawns, theme reload), and holding the lock
+    // across it would block the control thread's push. `into_inner` recovers a
+    // poisoned lock so one panic can't wedge the control path forever.
+    let batch: Vec<ClientMsg> = {
+        let mut q = queue.lock().unwrap_or_else(|e| e.into_inner());
+        q.drain(..).collect()
+    };
+    for msg in batch {
         core.apply(msg);
     }
     match ctl.swap(CTL_NONE, Ordering::SeqCst) {
@@ -356,7 +364,7 @@ fn serve_control(listener: UnixListener, ctl: Arc<AtomicU8>, queue: CtlQueue) {
                 // CLI or the desktop assistant) queues for the render loop.
                 Ok(msg) => {
                     crate::dbg_log(&format!("ctl: queued {msg:?}"));
-                    queue.lock().unwrap().push(msg);
+                    queue.lock().unwrap_or_else(|e| e.into_inner()).push(msg);
                 }
                 Err(_) => {}
             }

--- a/src/fileops.rs
+++ b/src/fileops.rs
@@ -310,9 +310,17 @@ impl SshFs {
     }
 
     /// Run `cmd` through `sh -c` on the remote; `None` on failure/timeout.
+    ///
+    /// NOTE: these calls currently run synchronously on the daemon's render
+    /// loop (via `FileManager` inside `core.apply`), so an unreachable remote
+    /// briefly freezes the desktop — bounded by `ConnectTimeout` (3s) plus the
+    /// per-op `secs` budget. The frequent navigation ops (list/home) use short
+    /// budgets to keep that hitch small; copy/move keep a generous budget for
+    /// large transfers. The proper fix is to move remote FsOps off the render
+    /// loop (like the scp paste already is) — tracked as a follow-up.
     fn ssh(&self, cmd: &str, secs: u64) -> Option<String> {
         let port = self.port.map(|p| p.to_string());
-        let mut args: Vec<&str> = vec!["-o", "BatchMode=yes", "-o", "ConnectTimeout=4"];
+        let mut args: Vec<&str> = vec!["-o", "BatchMode=yes", "-o", "ConnectTimeout=3"];
         if let Some(p) = port.as_deref() {
             args.extend(["-p", p]);
         }
@@ -328,7 +336,7 @@ impl SshFs {
     /// The remote home directory (the browser's starting point), or `None`
     /// when the system is unreachable / key auth is not set up.
     pub fn remote_home(&self) -> Option<PathBuf> {
-        let home = self.ssh("pwd", 6)?;
+        let home = self.ssh("pwd", 5)?;
         let home = home.trim();
         (!home.is_empty()).then(|| PathBuf::from(home))
     }
@@ -345,7 +353,7 @@ impl SshFs {
 impl FsOps for SshFs {
     fn list(&self, dir: &Path, show_hidden: bool) -> io::Result<Vec<Entry>> {
         let cmd = format!("cd {} && LC_ALL=C ls -lA", Self::q(dir));
-        let out = self.ssh(&cmd, 8).ok_or_else(|| Self::err("list"))?;
+        let out = self.ssh(&cmd, 5).ok_or_else(|| Self::err("list"))?;
         let mut entries = Vec::new();
         for line in out.lines() {
             let Some((kind, size, name)) = parse_ls_line(line) else { continue };

--- a/src/session.rs
+++ b/src/session.rs
@@ -3632,12 +3632,30 @@ fn take_reopen_hint() -> Option<u8> {
     code
 }
 
+/// Accept only well-formed git branch names; anything else falls back to
+/// `main`. The branch comes from `config.update_branch`, which a hand-edited
+/// config (or a typo) could set to junk — and it's interpolated into both a
+/// shell command and a URL below, so a stray quote/space would otherwise
+/// produce a broken updater run rather than a clean fallback.
+fn sanitize_branch(branch: &str) -> String {
+    let ok = !branch.is_empty()
+        && branch.len() <= 100
+        && branch
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '/' | '.'))
+        && !branch.starts_with('-')
+        && !branch.contains("..");
+    if ok { branch.to_string() } else { "main".to_string() }
+}
+
 /// The shell command that updates tuiui and reloads. On `main` it prefers the
 /// prebuilt release binary (a fast download via `install.sh`, jumping straight
 /// to the latest release), falling back to a source build; on any other branch
 /// (the dev channel) it builds that branch from git. On success it reloads and
 /// EXITS so the updater window auto-closes; only a failure drops to a shell.
 fn update_command(branch: &str) -> String {
+    let branch = sanitize_branch(branch);
+    let branch = branch.as_str();
     let repo = crate::REPO_URL;
     let raw = "https://raw.githubusercontent.com/jaylfc/tuiui";
     // Keep the new binary where the running one lives (cargo bin vs ~/.local/bin).
@@ -3712,6 +3730,8 @@ fn compat_dialog_buttons(w: i32, h: i32) -> (Rect, Rect) {
 
 /// Compare the installed commit against the tip of `branch` on GitHub.
 fn check_for_updates(branch: &str) -> String {
+    let branch = sanitize_branch(branch);
+    let branch = branch.as_str();
     let short = |s: &str| s.chars().take(7).collect::<String>();
     let api = format!(
         "https://api.github.com/repos/{}/commits/{branch}",
@@ -3781,6 +3801,22 @@ mod tests {
         assert!(cmd.contains("cargo install --git"), "dev builds from source");
         assert!(cmd.contains("--branch dev"), "on the dev branch: {cmd}");
         assert!(!cmd.contains("install.sh"), "no prebuilt release off main");
+    }
+
+    #[test]
+    fn junk_branch_falls_back_to_main() {
+        // A hand-edited / typo'd config branch must never leak shell syntax or a
+        // broken ref into the updater command or the check URL.
+        for junk in ["x; rm -rf ~", "a b", "evil'", "--force", "..", ""] {
+            assert_eq!(sanitize_branch(junk), "main", "rejected: {junk:?}");
+            let cmd = update_command(junk);
+            assert!(cmd.contains("install.sh"), "junk → the safe main path: {cmd}");
+            assert!(!cmd.contains("rm -rf"), "no injected payload survives: {cmd}");
+        }
+        // Legitimate branch names are preserved.
+        for ok in ["dev", "main", "feature/x", "release-1.2", "v0.2.0"] {
+            assert_eq!(sanitize_branch(ok), ok);
+        }
     }
 
     fn placement(x: i32, y: i32) -> crate::protocol::ImagePlacement {


### PR DESCRIPTION
Three robustness fixes surfaced by a code review of the networked seams:

1. **Updater branch validation** — `config.update_branch` is interpolated into a shell command and a URL; an invalid/typo'd value now falls back to `main` instead of producing a broken run.
2. **Control-socket lock** — `apply_ctl` no longer holds the queue lock across `core.apply` (was blocking the control thread), and both lock sites recover a poisoned lock so a panic can't wedge `tuiui launch/tile/theme/msg`.
3. **Remote file browser** — tighter navigation timeouts (ConnectTimeout 3s, list/home 5s) bound the desktop hitch when a saved system is unreachable; copy/move keep generous budgets. The full fix (remote FsOps off the render loop) is documented as a follow-up.

320 tests pass; clippy clean.

https://claude.ai/code/session_012HBi5A2gpLS8WzurJfqUG3

---
_Generated by [Claude Code](https://claude.ai/code/session_012HBi5A2gpLS8WzurJfqUG3)_