### PR TITLE
fix: window dragging stutter from per-frame activity refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to tuiui are recorded here. The project uses
 [semantic versioning](https://semver.org); while pre-1.0, minor versions may
 carry user-visible feature work and the occasional breaking config change.
 
+## [Unreleased]
+
+### Fixed
+- **Window dragging stutter**: moving (or resizing) a floating window felt
+  sticky and jerky once a few apps were open. The activity monitor's row
+  refresh was running every frame even while its panel was closed, and each
+  pass cloned every hosted app's full terminal grid just to read its size —
+  stalling the render loop mid-drag. The refresh now does nothing unless the
+  Activity Monitor window is actually open.
+
 ## [0.2.0] — 2026-06-10
 
 The "desktop, networked" release: switch between machines, an AI copilot, and

--- a/src/session.rs
+++ b/src/session.rs
@@ -2357,8 +2357,17 @@ impl SessionCore {
     }
 
     /// Rebuild the activity monitor's row list from the current `AppHost`.
-    /// Called every frame so the table stays live.
+    /// Called every frame so the table stays live — but only does any work when
+    /// the panel is actually open. Probing every hosted app each frame is costly
+    /// (`apphost_dims` clones a whole app grid via `snapshot`), so when the
+    /// window is closed we must not pay it: otherwise every render — including
+    /// each step of a window drag — stalls behind N full grid copies, which is
+    /// what makes dragging feel sticky/jerky.
     pub fn refresh_activity(&mut self) {
+        let win = match self.activity_win {
+            Some(id) if matches!(self.contents.get(&id), Some(WinContent::Activity(_))) => id,
+            _ => return,
+        };
         let entries: Vec<crate::apphost::AppListEntry> = self
             .apphost
             .list()
@@ -2385,10 +2394,8 @@ impl SessionCore {
                 }
             })
             .collect();
-        if let Some(id) = self.activity_win {
-            if let Some(WinContent::Activity(a)) = self.contents.get_mut(&id) {
-                a.set_rows(entries);
-            }
+        if let Some(WinContent::Activity(a)) = self.contents.get_mut(&win) {
+            a.set_rows(entries);
         }
     }
 


### PR DESCRIPTION
## Problem

Window dragging (and resizing) became sticky and jerky — the window wouldn't follow the cursor smoothly, especially with a few apps open.

## Root cause

The Activity Monitor (added in #13) wired `core.refresh_activity()` into the daemon's per-frame serve loop:

```rust
core.refresh_activity();
let frame = core.build_frame();
```

`refresh_activity()` ran **every frame regardless of whether the Activity panel was open**, and for each hosted app it called `apphost_dims()`, which calls `AppHost::snapshot()` purely to read the grid's width/height. `LocalAppHost::snapshot()` locks the app's terminal and rebuilds a **full cell-by-cell copy of the entire grid** — the single heaviest per-app operation.

So with N apps open, every rendered frame did N full grid clones just to throw them away. During a drag (many frames/second) this stalled the render loop, which is what made dragging feel sticky/jerky.

## Fix

`refresh_activity()` now early-returns unless the Activity Monitor window is actually open. Its rows are only ever consumed by that window, so nothing is lost — and the common case (panel closed) pays nothing per frame. When the panel *is* open the behavior is unchanged.

## Testing

- `cargo build` — clean
- `cargo test` — all green (300+ tests)
- The one `cargo clippy` error (`absurd_extreme_comparisons` on a `PROTO_VERSION >= MIN_COMPAT` test assertion at session.rs:3810) is pre-existing and unrelated — it's a Rust 1.96 lint that fires on the base commit too; the repo's MSRV is 1.95. My change is clippy-clean.

https://claude.ai/code/session_01XzWmWBQr7Hqd8RJgkbuc26

---
_Generated by [Claude Code](https://claude.ai/code/session_01XzWmWBQr7Hqd8RJgkbuc26)_