### PR TITLE
fix: updater loop on main channel + cut v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ carry user-visible feature work and the occasional breaking config change.
   pass cloned every hosted app's full terminal grid just to read its size —
   stalling the render loop mid-drag. The refresh now does nothing unless the
   Activity Monitor window is actually open.
+- **Update loop on the main channel**: "Check for updates" compared the
+  installed build against the tip of the `main` branch, but the main channel
+  installs the latest prebuilt *release*. Any commit landed on `main` after the
+  last release showed a permanent "update available" that re-installing the
+  same release could never clear. The check now compares against the latest
+  release's commit, matching what `install.sh` actually installs.
 
 ## [0.2.0] — 2026-06-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,14 @@ All notable changes to tuiui are recorded here. The project uses
 [semantic versioning](https://semver.org); while pre-1.0, minor versions may
 carry user-visible feature work and the occasional breaking config change.
 
-## [Unreleased]
+## [0.2.1] — 2026-06-13
+
+### Added
+- **Activity Monitor** (Ctrl+Space → A, or `@activity` in the launcher): a
+  live, auto-refreshing table of every app the apphost is hosting (id, pid,
+  command, age, dimensions, state) with kill-app controls and an Enter/y vs
+  Esc/n confirm for live apps. Also `tuiui ps` and `tuiui kill-app <id|all>`
+  CLI subcommands that work from any terminal or SSH session.
 
 ### Fixed
 - **Window dragging stutter**: moving (or resizing) a floating window felt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,10 @@ carry user-visible feature work and the occasional breaking config change.
   installed build against the tip of the `main` branch, but the main channel
   installs the latest prebuilt *release*. Any commit landed on `main` after the
   last release showed a permanent "update available" that re-installing the
-  same release could never clear. The check now compares against the latest
-  release's commit, matching what `install.sh` actually installs.
+  same release could never clear. The check now compares the installed version
+  against the latest release tag — matching what `install.sh` installs — and
+  reports it as versions (`v0.2.0 → v0.2.1`) instead of commit hashes. The dev
+  channel still tracks the branch tip and shows short commit hashes.
 
 ## [0.2.0] — 2026-06-10
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1109,7 +1109,7 @@ checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tuiui"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "alacritty_terminal",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuiui"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 rust-version = "1.95"
 license = "MIT"

--- a/src/session.rs
+++ b/src/session.rs
@@ -3761,15 +3761,18 @@ fn compat_dialog_buttons(w: i32, h: i32) -> (Rect, Rect) {
 }
 
 /// Check whether a newer build is available, comparing against whatever the
-/// update channel would actually install:
+/// update channel would actually install, and reporting it in that channel's
+/// own terms:
 /// - **main** installs the latest prebuilt *release* (via `install.sh`), so we
-///   compare against the release tag's commit — NOT the `main` branch tip.
-///   Comparing against the branch tip is a bug: any commit landed on `main`
-///   after the last release shows a permanent "update available" that
-///   re-installing the same release can never clear, i.e. an update loop.
-/// - **dev** builds the branch tip from source, so the branch tip is correct.
+///   compare the installed semver against the latest release tag and report
+///   versions (`v0.2.0 → v0.2.1`). Comparing against the `main` branch tip is a
+///   bug: any commit landed on `main` after the last release shows a permanent
+///   "update available" that re-installing the same release can never clear,
+///   i.e. an update loop.
+/// - **dev** builds the branch tip from source — there is no version there, so
+///   we compare the installed commit against the branch tip and report short
+///   commit hashes.
 fn check_for_updates(branch: &str) -> String {
-    let short = |s: &str| s.chars().take(7).collect::<String>();
     let repo = crate::REPO_URL.trim_start_matches("https://github.com/");
     let get_json = |path: &str| -> Option<serde_json::Value> {
         let url = format!("https://api.github.com/repos/{repo}/{path}");
@@ -3783,31 +3786,38 @@ fn check_for_updates(branch: &str) -> String {
     let str_field = |v: &serde_json::Value, k: &str| {
         v.get(k).and_then(|s| s.as_str()).map(str::to_string)
     };
-    // The commit the channel would install (the release tag's commit on main,
-    // the branch tip on dev), and the label shown to the user.
-    let (latest, on) = if branch == "main" {
-        // Resolve the latest release's tag, then that tag to a commit sha.
-        let sha = get_json("releases/latest")
-            .and_then(|v| str_field(&v, "tag_name"))
-            .and_then(|tag| get_json(&format!("commits/{tag}")))
-            .and_then(|v| str_field(&v, "sha"));
-        (sha, String::new())
-    } else {
-        let sha = get_json(&format!("commits/{branch}")).and_then(|v| str_field(&v, "sha"));
-        (sha, format!(" on {branch}"))
-    };
-    match latest {
-        Some(sha) => {
-            let cur = crate::GIT_SHA;
-            if cur == "unknown" {
-                format!("Latest is {}{on} — reinstall to update", short(&sha))
-            } else if sha.starts_with(cur) || cur.starts_with(&short(&sha)) {
-                format!("Up to date ({}){on}", short(cur))
-            } else {
-                format!("Update available{on}: {} → {}", short(cur), short(&sha))
-            }
+
+    if branch == "main" {
+        // Release channel: compare versions, show versions.
+        let tag = match get_json("releases/latest").and_then(|v| str_field(&v, "tag_name")) {
+            Some(t) => t,
+            None => return "Couldn't check (offline?)".to_string(),
+        };
+        let norm = |s: &str| s.trim_start_matches('v').to_string();
+        let latest = norm(&tag);
+        let cur = crate::VERSION; // CARGO_PKG_VERSION, e.g. "0.2.1"
+        if norm(cur) == latest {
+            format!("Up to date (v{cur})")
+        } else {
+            format!("Update available: v{cur} → v{latest}")
         }
-        None => "Couldn't check (offline?)".to_string(),
+    } else {
+        // Dev channel: compare commits, show short hashes.
+        let short = |s: &str| s.chars().take(7).collect::<String>();
+        let latest = get_json(&format!("commits/{branch}")).and_then(|v| str_field(&v, "sha"));
+        match latest {
+            Some(sha) => {
+                let cur = crate::GIT_SHA;
+                if cur == "unknown" {
+                    format!("Latest is {} on {branch} — reinstall to update", short(&sha))
+                } else if sha.starts_with(cur) || cur.starts_with(&short(&sha)) {
+                    format!("Up to date ({}) on {branch}", short(cur))
+                } else {
+                    format!("Update available on {branch}: {} → {}", short(cur), short(&sha))
+                }
+            }
+            None => "Couldn't check (offline?)".to_string(),
+        }
     }
 }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -3760,22 +3760,42 @@ fn compat_dialog_buttons(w: i32, h: i32) -> (Rect, Rect) {
     (keep, restart)
 }
 
-/// Compare the installed commit against the tip of `branch` on GitHub.
+/// Check whether a newer build is available, comparing against whatever the
+/// update channel would actually install:
+/// - **main** installs the latest prebuilt *release* (via `install.sh`), so we
+///   compare against the release tag's commit — NOT the `main` branch tip.
+///   Comparing against the branch tip is a bug: any commit landed on `main`
+///   after the last release shows a permanent "update available" that
+///   re-installing the same release can never clear, i.e. an update loop.
+/// - **dev** builds the branch tip from source, so the branch tip is correct.
 fn check_for_updates(branch: &str) -> String {
     let short = |s: &str| s.chars().take(7).collect::<String>();
-    let api = format!(
-        "https://api.github.com/repos/{}/commits/{branch}",
-        crate::REPO_URL.trim_start_matches("https://github.com/")
-    );
-    let out = std::process::Command::new("curl")
-        .args(["-fsS", "--max-time", "6", "-H", "User-Agent: tuiui", &api])
-        .output();
-    let latest = out
-        .ok()
-        .filter(|o| o.status.success())
-        .and_then(|o| serde_json::from_slice::<serde_json::Value>(&o.stdout).ok())
-        .and_then(|v| v.get("sha").and_then(|s| s.as_str()).map(str::to_string));
-    let on = if branch == "main" { String::new() } else { format!(" on {branch}") };
+    let repo = crate::REPO_URL.trim_start_matches("https://github.com/");
+    let get_json = |path: &str| -> Option<serde_json::Value> {
+        let url = format!("https://api.github.com/repos/{repo}/{path}");
+        std::process::Command::new("curl")
+            .args(["-fsS", "--max-time", "6", "-H", "User-Agent: tuiui", &url])
+            .output()
+            .ok()
+            .filter(|o| o.status.success())
+            .and_then(|o| serde_json::from_slice::<serde_json::Value>(&o.stdout).ok())
+    };
+    let str_field = |v: &serde_json::Value, k: &str| {
+        v.get(k).and_then(|s| s.as_str()).map(str::to_string)
+    };
+    // The commit the channel would install (the release tag's commit on main,
+    // the branch tip on dev), and the label shown to the user.
+    let (latest, on) = if branch == "main" {
+        // Resolve the latest release's tag, then that tag to a commit sha.
+        let sha = get_json("releases/latest")
+            .and_then(|v| str_field(&v, "tag_name"))
+            .and_then(|tag| get_json(&format!("commits/{tag}")))
+            .and_then(|v| str_field(&v, "sha"));
+        (sha, String::new())
+    } else {
+        let sha = get_json(&format!("commits/{branch}")).and_then(|v| str_field(&v, "sha"));
+        (sha, format!(" on {branch}"))
+    };
     match latest {
         Some(sha) => {
             let cur = crate::GIT_SHA;


### PR DESCRIPTION
## Updater loop fix

An instance on the **main** update channel gets stuck in an endless "update available" loop: it reports a newer version, the update runs and appears to succeed, but the version never advances and the next check shows the same prompt.

**Root cause — a version-reference mismatch.** The two halves of the updater compared different git references:

- **What it installs** (`main` channel): `install.sh` downloads the latest GitHub **release** → `/releases/latest` → `v0.2.0`, built at commit `1a276a8`.
- **What it checks** (`check_for_updates`): the tip of the **`main` branch** → `/commits/main` → `2ae3644` (a commit landed *after* v0.2.0, never released).

So installed = `1a276a8` (the release) vs branch tip = `2ae3644` → "Update available", the update reinstalls `v0.2.0` (still `1a276a8`), it never catches up, and the prompt never clears. An infinite loop re-installing can't resolve.

**Fix.** On the **main** channel, `check_for_updates` now resolves the latest release's tag to its commit and compares against *that* — what `install.sh` would actually install. The **dev** channel is unchanged (it builds the branch tip from source, so the branch tip is correct there).

## Also: cut v0.2.1

Bumps `Cargo.toml` to `0.2.1` and finalizes the CHANGELOG so a release can be published — delivering the Activity Monitor, the window-drag stutter fix, and this updater fix to main-channel users. After merge, the release workflow is dispatched at tag `v0.2.1`.

## Testing

- `cargo build` — clean
- `cargo test` — green

https://claude.ai/code/session_01XzWmWBQr7Hqd8RJgkbuc26