### PR TITLE
feat: optionally revoke SSH key when forgetting a system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,12 @@ carry user-visible feature work and the occasional breaking config change.
   opens a confirm with an opt-in *"Also revoke this PC's key on &lt;host&gt;"*
   toggle. When checked, removing the system also strips this machine's public
   key from that remote's `~/.ssh/authorized_keys` (the inverse of the key copy
-  that adding it performed) — exact full-line match only, keeping a `.tuiui.bak`.
-  It runs best-effort on a background thread, so an offline host never blocks the
-  removal or the UI; the local forget always succeeds.
+  that adding it performed). Exact full-line match only (never touches other
+  keys), across all your local identities; it rewrites the file in place inside
+  `~/.ssh` (preserving its `0600` perms and SELinux context) and keeps a
+  `.tuiui.bak`. Best-effort on a background thread — an offline host never blocks
+  the removal or the UI, the local forget always succeeds, and any remote-side
+  failure is logged rather than silently assumed done.
 
 ## [0.2.1] — 2026-06-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to tuiui are recorded here. The project uses
 [semantic versioning](https://semver.org); while pre-1.0, minor versions may
 carry user-visible feature work and the occasional breaking config change.
 
+## [Unreleased]
+
+### Added
+- **Revoke SSH key when forgetting a system**: the ✕ in the Systems menu now
+  opens a confirm with an opt-in *"Also revoke this PC's key on &lt;host&gt;"*
+  toggle. When checked, removing the system also strips this machine's public
+  key from that remote's `~/.ssh/authorized_keys` (the inverse of the key copy
+  that adding it performed) — exact full-line match only, keeping a `.tuiui.bak`.
+  It runs best-effort on a background thread, so an offline host never blocks the
+  removal or the UI; the local forget always succeeds.
+
 ## [0.2.1] — 2026-06-13
 
 ### Added

--- a/src/powermenu.rs
+++ b/src/powermenu.rs
@@ -62,8 +62,10 @@ pub enum PowerOutcome {
     /// Save a new system and switch to it with first-time setup (key transfer +
     /// remote install). The password is for setup only and is never persisted.
     AddAndConnect { system: RemoteSystem, password: Option<String> },
-    /// Remove a saved system (by name).
-    Forget(String),
+    /// Remove a saved system (by name). When `revoke` is `Some`, also strip this
+    /// machine's SSH key from that system's remote `authorized_keys` (best-effort
+    /// — the inverse of the key copy that adding it performed).
+    Forget { name: String, revoke: Option<RemoteSystem> },
 }
 
 /// Result of routing a click into an open power menu. While the menu is open it
@@ -89,6 +91,14 @@ pub struct AddForm {
 }
 
 const FORM_FIELDS: usize = 4;
+
+/// The "forget a system" confirmation, with an opt-in to also revoke this
+/// machine's SSH key on that remote.
+struct ForgetConfirm {
+    sys: RemoteSystem,
+    /// Whether to also strip our key from the remote's `authorized_keys`.
+    revoke: bool,
+}
 
 impl AddForm {
     /// Build the system + setup password from the form, if it is valid (the SSH
@@ -119,6 +129,8 @@ impl AddForm {
 pub struct PowerMenu {
     open: bool,
     confirm: Option<PowerAction>,
+    /// The "forget this system?" dialog (with the optional key-revoke toggle).
+    forget: Option<ForgetConfirm>,
     systems_open: bool,
     form: Option<AddForm>,
 }
@@ -206,6 +218,30 @@ fn dialog_buttons(w: i32, h: i32) -> (Rect, Rect) {
     (cancel, confirm)
 }
 
+/// The centered "forget a system" dialog — a touch taller than the power
+/// confirm to fit the revoke-key checkbox row.
+fn forget_dialog_rect(w: i32, h: i32) -> Rect {
+    let box_w = 56.min((w - 2).max(24));
+    let box_h = 9.min((h - 1).max(7));
+    Rect::new((w - box_w) / 2, ((h - box_h) / 2).max(0), box_w, box_h)
+}
+
+/// The clickable `[ ] Also revoke …` checkbox row inside the forget dialog.
+fn forget_checkbox_rect(w: i32, h: i32) -> Rect {
+    let d = forget_dialog_rect(w, h);
+    Rect::new(d.x + 2, d.y + 3, d.w - 4, 1)
+}
+
+/// Screen rects of the forget dialog's `(Cancel, Remove)` buttons.
+fn forget_buttons(w: i32, h: i32) -> (Rect, Rect) {
+    let d = forget_dialog_rect(w, h);
+    let by = d.y + d.h - 2;
+    let cancel = Rect::new(d.x + 2, by, 10, 1);
+    let remove_w = 14;
+    let remove = Rect::new(d.x + d.w - 2 - remove_w, by, remove_w, 1);
+    (cancel, remove)
+}
+
 impl PowerMenu {
     pub fn new() -> Self {
         Self::default()
@@ -214,7 +250,7 @@ impl PowerMenu {
     /// Whether the menu is showing anything (dropdown, submenu, form, or confirm
     /// dialog). When true the menu is modal and the session routes clicks to it.
     pub fn is_open(&self) -> bool {
-        self.open || self.confirm.is_some() || self.form.is_some()
+        self.open || self.confirm.is_some() || self.forget.is_some() || self.form.is_some()
     }
 
     /// Whether the Add Remote form is open (the client forwards typed chars).
@@ -235,6 +271,7 @@ impl PowerMenu {
     pub fn close(&mut self) {
         self.open = false;
         self.confirm = None;
+        self.forget = None;
         self.systems_open = false;
         self.form = None;
     }
@@ -350,6 +387,32 @@ impl PowerMenu {
             return PowerClick::Consumed;
         }
 
+        // The forget dialog is modal on top of the Systems submenu.
+        if let Some(fc) = self.forget.as_mut() {
+            let (cancel, remove) = forget_buttons(w, h);
+            if forget_checkbox_rect(w, h).contains(p) {
+                fc.revoke = !fc.revoke;
+                return PowerClick::Consumed;
+            }
+            if remove.contains(p) {
+                let name = fc.sys.name.clone();
+                let revoke = fc.revoke.then(|| fc.sys.clone());
+                self.close();
+                return PowerClick::Act(PowerOutcome::Forget { name, revoke });
+            }
+            if cancel.contains(p) {
+                // Back to the Systems submenu so a mis-click isn't a dead end.
+                self.forget = None;
+                self.open = true;
+                self.systems_open = true;
+                return PowerClick::Consumed;
+            }
+            if !forget_dialog_rect(w, h).contains(p) {
+                self.close();
+            }
+            return PowerClick::Consumed;
+        }
+
         // The confirm dialog is modal on top of the dropdown.
         if let Some(action) = self.confirm {
             let (cancel, confirm) = dialog_buttons(w, h);
@@ -385,8 +448,12 @@ impl PowerMenu {
             for (i, sys) in systems.iter().enumerate() {
                 let row = i + 1;
                 if forget_rect(w, n, row).contains(p) {
-                    let name = sys.name.clone();
-                    return PowerClick::Act(PowerOutcome::Forget(name));
+                    // The ✕ no longer removes instantly: open a confirm with the
+                    // optional "also revoke my key on the remote" toggle.
+                    self.forget = Some(ForgetConfirm { sys: sys.clone(), revoke: false });
+                    self.open = false;
+                    self.systems_open = false;
+                    return PowerClick::Consumed;
                 }
                 if systems_row_rect(w, n, row).contains(p) {
                     self.close();
@@ -572,6 +639,50 @@ impl PowerMenu {
             layers.push(Layer { z: 6000, origin: Point::new(d.x, d.y), buf, opacity: 1.0, scissor: None });
         }
 
+        if let Some(fc) = &self.forget {
+            let d = forget_dialog_rect(w, h);
+            let mut buf = CellBuffer::new(d.w, d.h);
+            buf.fill(Cell { ch: ' ', fg: t.text, bg: t.window_bg, attrs: Default::default() });
+            // Title bar.
+            for x in 0..d.w {
+                buf.set(x, 0, Cell { ch: ' ', fg: t.title_fg, bg: t.title_focus, attrs: Default::default() });
+            }
+            buf.write_str(2, 0, " tuiui ", t.title_fg, t.title_focus);
+            // Border.
+            let b = |ch: char| Cell { ch, fg: t.border, bg: t.window_bg, attrs: Default::default() };
+            for y in 1..d.h {
+                buf.set(0, y, b('│'));
+                buf.set(d.w - 1, y, b('│'));
+            }
+            for x in 0..d.w {
+                buf.set(x, d.h - 1, b('─'));
+            }
+            buf.set(0, d.h - 1, b('╰'));
+            buf.set(d.w - 1, d.h - 1, b('╯'));
+            // Message.
+            let msg: String = format!("Remove “{}”?", fc.sys.name)
+                .chars()
+                .take((d.w - 4) as usize)
+                .collect();
+            buf.write_str(2, 2, &msg, t.text, t.window_bg);
+            // Revoke-key checkbox (opt-in; off by default).
+            let cb = forget_checkbox_rect(w, h);
+            let mark = if fc.revoke { "▣" } else { "☐" };
+            let cb_fg = if fc.revoke { t.accent } else { t.dim };
+            let label: String = format!("{mark} Also revoke this PC's key on {}", fc.sys.host)
+                .chars()
+                .take(cb.w as usize)
+                .collect();
+            buf.write_str(cb.x - d.x, cb.y - d.y, &label, cb_fg, t.window_bg);
+            // Buttons.
+            let (cancel, remove) = forget_buttons(w, h);
+            let cancel_s = format!("{:^width$}", "Cancel", width = cancel.w as usize);
+            buf.write_str(cancel.x - d.x, cancel.y - d.y, &cancel_s, t.text, t.active_bg);
+            let remove_s = format!("{:^width$}", "Remove", width = remove.w as usize);
+            buf.write_str(remove.x - d.x, remove.y - d.y, &remove_s, t.close_fg, t.accent);
+            layers.push(Layer { z: 6000, origin: Point::new(d.x, d.y), buf, opacity: 1.0, scissor: None });
+        }
+
         layers
     }
 }
@@ -714,17 +825,59 @@ mod tests {
     }
 
     #[test]
-    fn forget_x_removes_a_system() {
+    fn forget_x_confirms_then_removes_without_revoke_by_default() {
         let (w, h) = (120, 40);
         let s = one_system();
         let mut m = PowerMenu::new();
         m.toggle();
         m.on_click(center(item_rect(w, SYSTEMS_ROW)), w, h, &s);
+        // The ✕ now opens a confirm, not an instant removal.
         let x = forget_rect(w, 1, 1);
+        assert_eq!(m.on_click(center(x), w, h, &s), PowerClick::Consumed);
+        assert!(m.forget.is_some(), "✕ opens the forget dialog");
+        // Removing with the (default-off) revoke toggle untouched.
+        let (_, remove) = forget_buttons(w, h);
         assert_eq!(
-            m.on_click(center(x), w, h, &s),
-            PowerClick::Act(PowerOutcome::Forget("pi".into()))
+            m.on_click(center(remove), w, h, &s),
+            PowerClick::Act(PowerOutcome::Forget { name: "pi".into(), revoke: None }),
+            "revoke is opt-in: off by default"
         );
+        assert!(!m.is_open());
+    }
+
+    #[test]
+    fn forget_with_revoke_checkbox_carries_the_system() {
+        let (w, h) = (120, 40);
+        let s = one_system();
+        let mut m = PowerMenu::new();
+        m.toggle();
+        m.on_click(center(item_rect(w, SYSTEMS_ROW)), w, h, &s);
+        m.on_click(center(forget_rect(w, 1, 1)), w, h, &s);
+        // Tick the revoke checkbox, then Remove.
+        assert_eq!(m.on_click(center(forget_checkbox_rect(w, h)), w, h, &s), PowerClick::Consumed);
+        let (_, remove) = forget_buttons(w, h);
+        match m.on_click(center(remove), w, h, &s) {
+            PowerClick::Act(PowerOutcome::Forget { name, revoke }) => {
+                assert_eq!(name, "pi");
+                let sys = revoke.expect("revoke carries the system to clean up");
+                assert_eq!(sys.host, "pi@10.0.0.2");
+            }
+            other => panic!("expected a Forget with revoke, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn forget_cancel_returns_to_systems_submenu() {
+        let (w, h) = (120, 40);
+        let s = one_system();
+        let mut m = PowerMenu::new();
+        m.toggle();
+        m.on_click(center(item_rect(w, SYSTEMS_ROW)), w, h, &s);
+        m.on_click(center(forget_rect(w, 1, 1)), w, h, &s);
+        let (cancel, _) = forget_buttons(w, h);
+        assert_eq!(m.on_click(center(cancel), w, h, &s), PowerClick::Consumed);
+        assert!(m.forget.is_none());
+        assert!(m.systems_open, "cancel drops back to the Systems list");
     }
 
     #[test]

--- a/src/session.rs
+++ b/src/session.rs
@@ -1179,7 +1179,8 @@ impl SessionCore {
                     ));
                 }
                 None => crate::dbg_log(&format!(
-                    "systems: revoke on '{}' failed (host unreachable or key already gone)",
+                    "systems: revoke on '{}' did not complete (host unreachable, auth refused, \
+or a remote-side error — its authorized_keys was left untouched)",
                     sys.name
                 )),
             }

--- a/src/session.rs
+++ b/src/session.rs
@@ -1145,14 +1145,45 @@ impl SessionCore {
                 self.switch_to = Some(spec);
                 self.quit = true;
             }
-            PowerOutcome::Forget(name) => {
-                crate::dbg_log(&format!("systems: forget '{name}'"));
+            PowerOutcome::Forget { name, revoke } => {
+                crate::dbg_log(&format!("systems: forget '{name}' (revoke={})", revoke.is_some()));
                 self.systems.retain(|s| s.name != name);
                 if let Err(e) = crate::systems::save(&self.systems) {
                     crate::dbg_log(&format!("systems: save failed: {e}"));
                 }
+                // Optionally strip our key from the remote — best-effort, on a
+                // background thread so an unreachable host can't stall the UI.
+                if let Some(sys) = revoke {
+                    Self::revoke_remote_key(sys);
+                }
             }
         }
+    }
+
+    /// Strip this machine's SSH key from a forgotten system's remote
+    /// `authorized_keys` (the inverse of the key copy that adding it performed).
+    /// Runs on a detached thread: ssh can take seconds or hang on an unreachable
+    /// host, and the render loop must never wait on the network. Best-effort —
+    /// every outcome is logged for the in-app Logs viewer, nothing is surfaced.
+    fn revoke_remote_key(sys: crate::systems::RemoteSystem) {
+        std::thread::spawn(move || {
+            crate::dbg_log(&format!("systems: revoking key on '{}' ({})", sys.name, sys.host));
+            let script = crate::systems::revoke_script(&sys.host, sys.port);
+            match crate::system::run_capped("sh", &["-c", &script], 15) {
+                Some(out) => {
+                    let tail = out.trim();
+                    crate::dbg_log(&format!(
+                        "systems: revoke on '{}' done{}",
+                        sys.name,
+                        if tail.is_empty() { String::new() } else { format!(" — {tail}") }
+                    ));
+                }
+                None => crate::dbg_log(&format!(
+                    "systems: revoke on '{}' failed (host unreachable or key already gone)",
+                    sys.name
+                )),
+            }
+        });
     }
 
     /// Build the launcher's app list: the configured apps (with categories filled

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -232,6 +232,37 @@ fi\n",
     s
 }
 
+/// The local shell script that removes *this* machine's public key(s) from a
+/// remote's `~/.ssh/authorized_keys` — the inverse of the `ssh-copy-id` that
+/// [`switch_script`]'s setup performs. It is best-effort and non-interactive
+/// (`BatchMode=yes`, short `ConnectTimeout`): it authenticates with the very key
+/// it is revoking, filters that exact full line out of `authorized_keys`
+/// (keeping a `.tuiui.bak`), and leaves any other keys untouched. A missing
+/// local key or an unreachable host is a quiet no-op, never a hang.
+pub fn revoke_script(host: &str, port: Option<u16>) -> String {
+    let target = sh_quote(host);
+    let pf = port_flag(port);
+    // Remote side: read our piped public keys into a temp file, drop only the
+    // lines that match one of them *exactly* (`grep -vxF`), keeping a backup.
+    // grep rc 0 (some kept) and 1 (none kept → file becomes empty, which is
+    // correct when ours was the only key) are both success; rc >= 2 is a real
+    // error, so we leave authorized_keys untouched.
+    let remote = sh_quote(
+        "ak=\"$HOME/.ssh/authorized_keys\"; [ -f \"$ak\" ] || exit 0; \
+f=$(mktemp) || exit 0; cat > \"$f\"; cp \"$ak\" \"$ak.tuiui.bak\" 2>/dev/null; \
+grep -vxFf \"$f\" \"$ak\" > \"$f.out\"; rc=$?; \
+if [ \"$rc\" -le 1 ]; then mv \"$f.out\" \"$ak\"; else rm -f \"$f.out\"; fi; rm -f \"$f\"",
+    );
+    // Local side: bail (loudly) when there is no public key to revoke, else cat
+    // the default identities and pipe them to the remote filter above.
+    format!(
+        "have=0; for p in \"$HOME/.ssh/id_ed25519.pub\" \"$HOME/.ssh/id_rsa.pub\"; do [ -f \"$p\" ] && have=1; done; \
+if [ \"$have\" = 0 ]; then echo 'tuiui: no local SSH public key to revoke'; exit 0; fi; \
+{{ for p in \"$HOME/.ssh/id_ed25519.pub\" \"$HOME/.ssh/id_rsa.pub\"; do [ -f \"$p\" ] && cat \"$p\"; done; }} | \
+ssh -o BatchMode=yes -o ConnectTimeout=8 {pf}{target} {remote}"
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -265,6 +296,19 @@ mod tests {
         assert!(s.contains("infocmp"), "guards against missing remote terminfo: {s}");
         assert!(s.contains("TERM=xterm-256color"), "falls back to a universal TERM: {s}");
         assert!(!s.contains("ssh-copy-id"), "no setup steps on a plain switch");
+    }
+
+    #[test]
+    fn revoke_script_filters_our_key_best_effort() {
+        let s = revoke_script("pi@10.0.0.2", Some(2222));
+        assert!(s.contains("ssh -o BatchMode=yes"), "non-interactive: {s}");
+        assert!(s.contains("ConnectTimeout=8"), "bounded connect: {s}");
+        assert!(s.contains("-p 2222 "), "carries the custom port: {s}");
+        assert!(s.contains("'pi@10.0.0.2'"), "targets the host: {s}");
+        assert!(s.contains("grep -vxFf"), "removes exact full-line key matches: {s}");
+        assert!(s.contains(".tuiui.bak"), "keeps a backup: {s}");
+        assert!(s.contains("id_ed25519.pub") && s.contains("id_rsa.pub"), "considers both default keys: {s}");
+        assert!(s.contains("no local SSH public key to revoke"), "no-ops cleanly with no key: {s}");
     }
 
     #[test]

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -238,28 +238,43 @@ fi\n",
 /// (`BatchMode=yes`, short `ConnectTimeout`): it authenticates with the very key
 /// it is revoking, filters that exact full line out of `authorized_keys`
 /// (keeping a `.tuiui.bak`), and leaves any other keys untouched. A missing
-/// local key or an unreachable host is a quiet no-op, never a hang.
+/// local key or an unreachable host is a quiet no-op, never a hang; any real
+/// remote-side failure exits non-zero so the caller can log it truthfully.
 pub fn revoke_script(host: &str, port: Option<u16>) -> String {
     let target = sh_quote(host);
     let pf = port_flag(port);
-    // Remote side: read our piped public keys into a temp file, drop only the
-    // lines that match one of them *exactly* (`grep -vxF`), keeping a backup.
-    // grep rc 0 (some kept) and 1 (none kept → file becomes empty, which is
-    // correct when ours was the only key) are both success; rc >= 2 is a real
-    // error, so we leave authorized_keys untouched.
+    // Remote side: filter our piped public keys out of authorized_keys, dropping
+    // only lines that match one *exactly* (`grep -vxF`). Both the scratch file
+    // and the result live *inside* `~/.ssh`, never `/tmp`: a file `mv`d in from
+    // `/tmp` can carry a `tmp_t` SELinux label (or cross a filesystem) and make
+    // sshd refuse the whole file, silently locking the user out of every key.
+    // We `chmod 600` before the swap (shell redirection would leave it
+    // world-readable) and back up first, aborting if the backup can't be made.
+    // grep rc 0/1 are both success (1 = ours was the only line → file becomes
+    // empty); rc >= 2 is a real error. Every failure exits non-zero so the
+    // caller logs an honest failure instead of a misleading "done".
     let remote = sh_quote(
         "ak=\"$HOME/.ssh/authorized_keys\"; [ -f \"$ak\" ] || exit 0; \
-f=$(mktemp) || exit 0; cat > \"$f\"; cp \"$ak\" \"$ak.tuiui.bak\" 2>/dev/null; \
-grep -vxFf \"$f\" \"$ak\" > \"$f.out\"; rc=$?; \
-if [ \"$rc\" -le 1 ]; then mv \"$f.out\" \"$ak\"; else rm -f \"$f.out\"; fi; rm -f \"$f\"",
+in=\"$ak.tuiui.in\"; out=\"$ak.tuiui.tmp\"; \
+cat > \"$in\" || { rm -f \"$in\"; exit 2; }; \
+cp \"$ak\" \"$ak.tuiui.bak\" || { echo 'tuiui: backup failed'; rm -f \"$in\"; exit 2; }; \
+grep -vxFf \"$in\" \"$ak\" > \"$out\"; rc=$?; \
+if [ \"$rc\" -le 1 ]; then chmod 600 \"$out\"; mv \"$out\" \"$ak\" || { rm -f \"$in\" \"$out\"; exit 2; }; \
+else rm -f \"$in\" \"$out\"; exit \"$rc\"; fi; \
+rm -f \"$in\"; exit 0",
     );
-    // Local side: bail (loudly) when there is no public key to revoke, else cat
-    // the default identities and pipe them to the remote filter above.
+    // Local side: collect every *readable* local public identity — all
+    // `~/.ssh/*.pub` plus any agent-held keys — because `ssh-copy-id` (run
+    // without `-i` at setup) may have installed any of them, not just the
+    // ed25519/rsa defaults. Bail cleanly when there are none, else pipe them to
+    // the remote filter and propagate its exit status.
     format!(
-        "have=0; for p in \"$HOME/.ssh/id_ed25519.pub\" \"$HOME/.ssh/id_rsa.pub\"; do [ -f \"$p\" ] && have=1; done; \
-if [ \"$have\" = 0 ]; then echo 'tuiui: no local SSH public key to revoke'; exit 0; fi; \
-{{ for p in \"$HOME/.ssh/id_ed25519.pub\" \"$HOME/.ssh/id_rsa.pub\"; do [ -f \"$p\" ] && cat \"$p\"; done; }} | \
-ssh -o BatchMode=yes -o ConnectTimeout=8 {pf}{target} {remote}"
+        "kf=$(mktemp) || exit 1; \
+{{ for p in \"$HOME\"/.ssh/*.pub; do [ -r \"$p\" ] && cat \"$p\"; done; \
+command -v ssh-add >/dev/null 2>&1 && ssh-add -L 2>/dev/null; }} \
+| grep -v '^$' | sort -u > \"$kf\"; \
+if [ ! -s \"$kf\" ]; then echo 'tuiui: no local SSH public key to revoke'; rm -f \"$kf\"; exit 0; fi; \
+ssh -o BatchMode=yes -o ConnectTimeout=8 {pf}{target} {remote} < \"$kf\"; rc=$?; rm -f \"$kf\"; exit \"$rc\""
     )
 }
 
@@ -307,7 +322,12 @@ mod tests {
         assert!(s.contains("'pi@10.0.0.2'"), "targets the host: {s}");
         assert!(s.contains("grep -vxFf"), "removes exact full-line key matches: {s}");
         assert!(s.contains(".tuiui.bak"), "keeps a backup: {s}");
-        assert!(s.contains("id_ed25519.pub") && s.contains("id_rsa.pub"), "considers both default keys: {s}");
+        assert!(s.contains("backup failed"), "aborts if the backup can't be made: {s}");
+        assert!(s.contains("chmod 600"), "tightens perms before swapping in: {s}");
+        assert!(s.contains("$ak.tuiui.tmp"), "writes the result inside ~/.ssh, not /tmp: {s}");
+        assert!(s.contains("/.ssh/*.pub"), "considers every local public identity: {s}");
+        assert!(s.contains("ssh-add -L"), "also covers agent-held keys: {s}");
+        assert!(s.contains("[ -r "), "only reads readable key files: {s}");
         assert!(s.contains("no local SSH public key to revoke"), "no-ops cleanly with no key: {s}");
     }
 


### PR DESCRIPTION
## What

When you remove (✕) a saved machine from the top-right **Systems** menu, tuiui can now also revoke this PC's SSH key from that remote — the inverse of the key copy that adding it performed.

## Why

Adding a system runs `ssh-copy-id`, appending this machine's public key to the remote's `~/.ssh/authorized_keys`. Until now, forgetting a system only dropped the **local** entry and left that key behind on the remote forever — a lingering credential with no cleanup path.

## How

- The ✕ no longer removes instantly: it opens a confirm dialog with an **opt-in** checkbox — *"Also revoke this PC's key on `<host>`"* — **off by default**.
- On **Remove** with the box ticked, tuiui strips our key from the remote's `authorized_keys`:
  - **exact full-line match only** (`grep -vxFf`) — never touches other keys;
  - keeps a `.tuiui.bak` backup; grep rc ≤ 1 is treated as success (rc 1 = ours was the only key → file becomes empty, which is correct), rc ≥ 2 leaves the file untouched;
  - non-interactive (`ssh -o BatchMode=yes -o ConnectTimeout=8`) so it fails fast instead of hanging on a prompt;
  - runs on a **detached thread** via `run_capped`, so an offline/unreachable host never blocks the local forget or stalls the render loop.
- The local forget always succeeds regardless; revoke is best-effort and fully logged for the in-app Logs viewer.

## Tests

- `systems::revoke_script_*` — script targets the host/port, uses BatchMode + ConnectTimeout, exact-match filter, keeps a backup, no-ops cleanly with no local key.
- `powermenu::forget_*` — ✕ opens the confirm (no instant removal); Remove without the toggle → `Forget { revoke: None }`; with the toggle → carries the system to clean up; Cancel returns to the Systems submenu.
- Full suite green; clippy clean.

https://claude.ai/code/session_01XzWmWBQr7Hqd8RJgkbuc26

---
_Generated by [Claude Code](https://claude.ai/code/session_01XzWmWBQr7Hqd8RJgkbuc26)_