### PR TITLE
fix: address post-merge review findings on #21 (hidden activity refresh) and #22 (semver update check)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,9 @@ carry user-visible feature work and the occasional breaking config change.
 - **Update check no longer offers downgrades**: the main-channel version
   comparison was a plain string compare, so a local build *newer* than the
   latest release (mid-release-cut, or a dev/source build) showed a bogus
-  "update available → older version". It is now semver-aware and only offers a
-  strictly-newer release.
+  "update available → older version". It now compares release version numbers
+  (`major.minor.patch`) and only offers a strictly-newer release; an
+  unparseable release tag reports "couldn't check" instead of guessing.
 
 ## [0.2.1] — 2026-06-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,17 @@ carry user-visible feature work and the occasional breaking config change.
   the removal or the UI, the local forget always succeeds, and any remote-side
   failure is logged rather than silently assumed done.
 
+### Fixed
+- **Activity Monitor refresh while hidden**: the per-frame app snapshot was
+  still running when the Activity panel was open but **minimized** (or hidden in
+  simple mode), so the window-drag stutter could persist in those states. The
+  refresh now also requires the panel to be visible.
+- **Update check no longer offers downgrades**: the main-channel version
+  comparison was a plain string compare, so a local build *newer* than the
+  latest release (mid-release-cut, or a dev/source build) showed a bogus
+  "update available → older version". It is now semver-aware and only offers a
+  strictly-newer release.
+
 ## [0.2.1] — 2026-06-13
 
 ### Added

--- a/src/session.rs
+++ b/src/session.rs
@@ -2390,14 +2390,23 @@ or a remote-side error — its authorized_keys was left untouched)",
 
     /// Rebuild the activity monitor's row list from the current `AppHost`.
     /// Called every frame so the table stays live — but only does any work when
-    /// the panel is actually open. Probing every hosted app each frame is costly
-    /// (`apphost_dims` clones a whole app grid via `snapshot`), so when the
-    /// window is closed we must not pay it: otherwise every render — including
-    /// each step of a window drag — stalls behind N full grid copies, which is
-    /// what makes dragging feel sticky/jerky.
+    /// the panel is actually *visible*. Probing every hosted app each frame is
+    /// costly (`apphost_dims` clones a whole app grid via `snapshot`), so we must
+    /// not pay it when the rows aren't on screen: otherwise every render —
+    /// including each step of a window drag — stalls behind N full grid copies,
+    /// which is what makes dragging feel sticky/jerky. A minimized panel (skipped
+    /// by `build_frame`), or a non-focused one in simple mode (hidden by
+    /// `build_frame_simple`), counts as not visible.
     pub fn refresh_activity(&mut self) {
         let win = match self.activity_win {
-            Some(id) if matches!(self.contents.get(&id), Some(WinContent::Activity(_))) => id,
+            Some(id)
+                if matches!(self.contents.get(&id), Some(WinContent::Activity(_)))
+                    && self.wm.get(id).is_some_and(|w| {
+                        !w.minimized && (!self.simple || self.wm.focused() == Some(id))
+                    }) =>
+            {
+                id
+            }
             _ => return,
         };
         let entries: Vec<crate::apphost::AppListEntry> = self
@@ -3825,13 +3834,16 @@ fn check_for_updates(branch: &str) -> String {
             Some(t) => t,
             None => return "Couldn't check (offline?)".to_string(),
         };
-        let norm = |s: &str| s.trim_start_matches('v').to_string();
-        let latest = norm(&tag);
+        let latest = tag.trim_start_matches('v');
         let cur = crate::VERSION; // CARGO_PKG_VERSION, e.g. "0.2.1"
-        if norm(cur) == latest {
-            format!("Up to date (v{cur})")
-        } else {
+        // Only offer the update when the release is *strictly newer* (semver):
+        // a plain string compare would prompt a downgrade when the local build
+        // is ahead of the latest tag — e.g. mid-release-cut, or a dev/source
+        // build whose version outruns the published release.
+        if semver_tuple(latest) > semver_tuple(cur) {
             format!("Update available: v{cur} → v{latest}")
+        } else {
+            format!("Up to date (v{cur})")
         }
     } else {
         // Dev channel: compare commits, show short hashes.
@@ -3851,6 +3863,16 @@ fn check_for_updates(branch: &str) -> String {
             None => "Couldn't check (offline?)".to_string(),
         }
     }
+}
+
+/// Parse a dotted version (`"0.2.1"`, with an optional leading `v` already
+/// stripped and any `-pre`/`+build` suffix ignored) into a comparable
+/// `(major, minor, patch)` tuple. Unparseable parts read as 0, so two odd tags
+/// just compare equal rather than panicking.
+fn semver_tuple(v: &str) -> (u64, u64, u64) {
+    let core = v.trim_start_matches('v').split(['-', '+']).next().unwrap_or(v);
+    let mut it = core.split('.').map(|p| p.trim().parse::<u64>().unwrap_or(0));
+    (it.next().unwrap_or(0), it.next().unwrap_or(0), it.next().unwrap_or(0))
 }
 
 #[cfg(test)]
@@ -3889,6 +3911,20 @@ mod tests {
         assert!(cmd.contains("cargo install --git"), "dev builds from source");
         assert!(cmd.contains("--branch dev"), "on the dev branch: {cmd}");
         assert!(!cmd.contains("install.sh"), "no prebuilt release off main");
+    }
+
+    #[test]
+    fn semver_tuple_orders_versions_and_never_downgrades() {
+        // Newer release than installed → an update is offered.
+        assert!(semver_tuple("0.2.2") > semver_tuple("0.2.1"));
+        assert!(semver_tuple("0.3.0") > semver_tuple("0.2.9"));
+        assert!(semver_tuple("1.0.0") > semver_tuple("0.9.9"));
+        // Installed >= latest release → no downgrade prompt.
+        assert!(!(semver_tuple("0.2.0") > semver_tuple("0.2.1")), "local ahead of release");
+        assert!(!(semver_tuple("0.2.1") > semver_tuple("0.2.1")), "equal = up to date");
+        // Leading v and pre-release/build suffixes are ignored for ordering.
+        assert_eq!(semver_tuple("v0.2.1"), semver_tuple("0.2.1"));
+        assert_eq!(semver_tuple("0.2.1-rc1"), semver_tuple("0.2.1"));
     }
 
     fn placement(x: i32, y: i32) -> crate::protocol::ImagePlacement {

--- a/src/session.rs
+++ b/src/session.rs
@@ -3836,14 +3836,17 @@ fn check_for_updates(branch: &str) -> String {
         };
         let latest = tag.trim_start_matches('v');
         let cur = crate::VERSION; // CARGO_PKG_VERSION, e.g. "0.2.1"
-        // Only offer the update when the release is *strictly newer* (semver):
-        // a plain string compare would prompt a downgrade when the local build
-        // is ahead of the latest tag — e.g. mid-release-cut, or a dev/source
-        // build whose version outruns the published release.
-        if semver_tuple(latest) > semver_tuple(cur) {
-            format!("Update available: v{cur} → v{latest}")
-        } else {
-            format!("Up to date (v{cur})")
+        // Only offer the update when the release is *strictly newer*: a plain
+        // string compare would prompt a downgrade when the local build is ahead
+        // of the latest tag — e.g. mid-release-cut, or a dev/source build whose
+        // version outruns the published release. A release tag we can't parse is
+        // reported as a check failure rather than silently treated as 0.0.0.
+        match semver_tuple(latest) {
+            Some(l) if Some(l) > semver_tuple(cur) => {
+                format!("Update available: v{cur} → v{latest}")
+            }
+            Some(_) => format!("Up to date (v{cur})"),
+            None => format!("Couldn't check (unexpected release tag '{tag}')"),
         }
     } else {
         // Dev channel: compare commits, show short hashes.
@@ -3865,14 +3868,26 @@ fn check_for_updates(branch: &str) -> String {
     }
 }
 
-/// Parse a dotted version (`"0.2.1"`, with an optional leading `v` already
-/// stripped and any `-pre`/`+build` suffix ignored) into a comparable
-/// `(major, minor, patch)` tuple. Unparseable parts read as 0, so two odd tags
-/// just compare equal rather than panicking.
-fn semver_tuple(v: &str) -> (u64, u64, u64) {
-    let core = v.trim_start_matches('v').split(['-', '+']).next().unwrap_or(v);
-    let mut it = core.split('.').map(|p| p.trim().parse::<u64>().unwrap_or(0));
-    (it.next().unwrap_or(0), it.next().unwrap_or(0), it.next().unwrap_or(0))
+/// Parse a `MAJOR.MINOR.PATCH` version (a leading `v` is tolerated) into a
+/// comparable tuple, or `None` if it doesn't look like one. This is a numeric
+/// `major.minor.patch` comparison, *not* full semver: any `-pre`/`+build`
+/// suffix is dropped before parsing (tuiui only ever ships plain release
+/// versions, so pre-release precedence never comes up). A component that isn't
+/// a number makes the whole thing `None`, so a malformed release tag surfaces
+/// as a check failure instead of silently comparing as `0.0.0`.
+fn semver_tuple(v: &str) -> Option<(u64, u64, u64)> {
+    let core = v.trim().trim_start_matches('v').split(['-', '+']).next().unwrap_or("");
+    if core.is_empty() {
+        return None;
+    }
+    let mut parts = [0u64; 3];
+    for (i, p) in core.split('.').enumerate() {
+        if i >= 3 {
+            break;
+        }
+        parts[i] = p.trim().parse::<u64>().ok()?;
+    }
+    Some((parts[0], parts[1], parts[2]))
 }
 
 #[cfg(test)]
@@ -3922,9 +3937,14 @@ mod tests {
         // Installed >= latest release → no downgrade prompt.
         assert!(!(semver_tuple("0.2.0") > semver_tuple("0.2.1")), "local ahead of release");
         assert!(!(semver_tuple("0.2.1") > semver_tuple("0.2.1")), "equal = up to date");
-        // Leading v and pre-release/build suffixes are ignored for ordering.
-        assert_eq!(semver_tuple("v0.2.1"), semver_tuple("0.2.1"));
-        assert_eq!(semver_tuple("0.2.1-rc1"), semver_tuple("0.2.1"));
+        // Leading v and (ignored) pre-release/build suffixes parse to the core.
+        assert_eq!(semver_tuple("v0.2.1"), Some((0, 2, 1)));
+        assert_eq!(semver_tuple("0.2.1-rc1"), Some((0, 2, 1)));
+        assert_eq!(semver_tuple("0.2"), Some((0, 2, 0)), "missing patch defaults to 0");
+        // Malformed tags are None (→ "couldn't check"), not a silent 0.0.0.
+        assert_eq!(semver_tuple("not-a-version"), None);
+        assert_eq!(semver_tuple(""), None);
+        assert_eq!(semver_tuple("v"), None);
     }
 
     fn placement(x: i32, y: i32) -> crate::protocol::ImagePlacement {

--- a/src/session.rs
+++ b/src/session.rs
@@ -3869,25 +3869,23 @@ fn check_for_updates(branch: &str) -> String {
 }
 
 /// Parse a `MAJOR.MINOR.PATCH` version (a leading `v` is tolerated) into a
-/// comparable tuple, or `None` if it doesn't look like one. This is a numeric
+/// comparable tuple, or `None` if it isn't exactly that. This is a numeric
 /// `major.minor.patch` comparison, *not* full semver: any `-pre`/`+build`
 /// suffix is dropped before parsing (tuiui only ever ships plain release
-/// versions, so pre-release precedence never comes up). A component that isn't
-/// a number makes the whole thing `None`, so a malformed release tag surfaces
-/// as a check failure instead of silently comparing as `0.0.0`.
+/// versions, so pre-release precedence never comes up). Anything that isn't
+/// three numeric components — too few, too many, or non-numeric — is `None`, so
+/// a malformed release tag surfaces as a check failure instead of silently
+/// comparing as `0.0.0`.
 fn semver_tuple(v: &str) -> Option<(u64, u64, u64)> {
     let core = v.trim().trim_start_matches('v').split(['-', '+']).next().unwrap_or("");
-    if core.is_empty() {
-        return None;
+    let mut it = core.split('.');
+    let major = it.next()?.trim().parse::<u64>().ok()?;
+    let minor = it.next()?.trim().parse::<u64>().ok()?;
+    let patch = it.next()?.trim().parse::<u64>().ok()?;
+    if it.next().is_some() {
+        return None; // a fourth component → not a MAJOR.MINOR.PATCH version
     }
-    let mut parts = [0u64; 3];
-    for (i, p) in core.split('.').enumerate() {
-        if i >= 3 {
-            break;
-        }
-        parts[i] = p.trim().parse::<u64>().ok()?;
-    }
-    Some((parts[0], parts[1], parts[2]))
+    Some((major, minor, patch))
 }
 
 #[cfg(test)]
@@ -3940,8 +3938,10 @@ mod tests {
         // Leading v and (ignored) pre-release/build suffixes parse to the core.
         assert_eq!(semver_tuple("v0.2.1"), Some((0, 2, 1)));
         assert_eq!(semver_tuple("0.2.1-rc1"), Some((0, 2, 1)));
-        assert_eq!(semver_tuple("0.2"), Some((0, 2, 0)), "missing patch defaults to 0");
-        // Malformed tags are None (→ "couldn't check"), not a silent 0.0.0.
+        // Anything that isn't exactly MAJOR.MINOR.PATCH is None (→ "couldn't
+        // check"), not a silent 0.0.0 / truncation.
+        assert_eq!(semver_tuple("0.2"), None, "too few components");
+        assert_eq!(semver_tuple("0.2.1.4"), None, "too many components");
         assert_eq!(semver_tuple("not-a-version"), None);
         assert_eq!(semver_tuple(""), None);
         assert_eq!(semver_tuple("v"), None);


### PR DESCRIPTION
## What

Two legitimate findings raised by review bots **after** PRs #21 and #22 had already merged into v0.2.1, so they were never addressed. Both are small, real bugs in shipped behavior.

### 1. Activity Monitor refresh while hidden (from #21)
My drag-stutter fix gated `refresh_activity()` on the Activity panel *existing*, but a panel that's open-but-**minimized** (skipped by `build_frame`) or non-focused in **simple mode** (hidden by `build_frame_simple`) still paid the full per-frame cost — snapshotting (deep-cloning) every hosted app's grid — so the stutter could persist in those states.

**Fix:** the refresh now also requires the panel to be *visible* (`!minimized`, and focused when in simple mode).

### 2. Update check could prompt a downgrade (from #22)
The main-channel check compared version **strings** for equality. When the local build is *newer* than the latest release tag — during a release cut, or any dev/source build whose version outruns the published release — it showed a bogus `Update available: v0.2.1 → v0.2.0`.

**Fix:** added a small `semver_tuple()` and compare numerically; an update is offered only when the release is **strictly newer**. Otherwise it reads "Up to date".

## Note on the bots

CodeRabbit was rate-limited for the entire window and never actually reviewed #21/#22/#23 — Kilo/Qodo/Gitar did. These two were Kilo's findings that landed after merge. #23's findings were all addressed before it merged.

## Tests

- New `semver_tuple_orders_versions_and_never_downgrades` unit test (ordering, no-downgrade, `v`-prefix and pre-release suffix handling).
- Full suite green; clippy clean.

https://claude.ai/code/session_01XzWmWBQr7Hqd8RJgkbuc26

---
_Generated by [Claude Code](https://claude.ai/code/session_01XzWmWBQr7Hqd8RJgkbuc26)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Activity Monitor refresh stutter that occurred when the panel remained open but was minimized or hidden from view, eliminating unnecessary performance overhead
  * Enhanced update checking for the main release channel with semantic version comparison to prevent downgrade prompts and ensure only strictly newer versions are suggested

<!-- end of auto-generated comment: release notes by coderabbit.ai -->