### PR TITLE
chore: make cargo clippy --all-targets clean (MIN_COMPAT guard)

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -3880,7 +3880,12 @@ mod tests {
         // The current binary pair is always compatible with itself (a const
         // block so a bad MIN_COMPAT bump fails the BUILD, not just this test).
         const {
-            assert!(crate::apphost::proto::PROTO_VERSION >= crate::apphost::proto::MIN_COMPAT);
+            // MIN_COMPAT is 0 today, so this reads as "always true" to clippy —
+            // but it's a deliberate build-time guard for future bumps.
+            #[allow(clippy::absurd_extreme_comparisons)]
+            {
+                assert!(crate::apphost::proto::PROTO_VERSION >= crate::apphost::proto::MIN_COMPAT);
+            }
         }
     }
 


### PR DESCRIPTION
The const-block assertion `PROTO_VERSION >= MIN_COMPAT` in `session.rs` is a deliberate **build-time guard** — if a future change bumps `MIN_COMPAT` past `PROTO_VERSION`, the build fails. But because `MIN_COMPAT` is `0` today, clippy's `absurd_extreme_comparisons` reads it as "always true" and errors under `cargo clippy --all-targets` (on Rust 1.96). This was pre-existing on `main` and CI doesn't run clippy, so it never blocked anything — but it kept `--all-targets` from being clean.

Scope a local `#[allow(clippy::absurd_extreme_comparisons)]` to just that assert (with a comment explaining why the guard stays). The guard's behavior is unchanged.

`cargo clippy --all-targets` is now fully clean; tests green.

https://claude.ai/code/session_01XzWmWBQr7Hqd8RJgkbuc26

---
_Generated by [Claude Code](https://claude.ai/code/session_01XzWmWBQr7Hqd8RJgkbuc26)_