### PR TITLE
release: 0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ carry user-visible feature work and the occasional breaking config change.
 
 ## [Unreleased]
 
+## [0.2.2] — 2026-06-13
+
 ### Changed
 - **Assistant standardised on opencode**: the ✦ assistant now runs a single
   agent CLI — **opencode** (model-agnostic, MCP-extensible) — instead of a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1109,7 +1109,7 @@ checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tuiui"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "alacritty_terminal",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuiui"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 rust-version = "1.95"
 license = "MIT"


### PR DESCRIPTION
Cut the **0.2.2** release: roll the `[Unreleased]` changelog into a dated `[0.2.2] — 2026-06-13` section and bump the crate version `0.2.1 → 0.2.2` (Cargo.toml + Cargo.lock).

### What ships in 0.2.2
- **Assistant standardised on opencode** (#25) — single model-agnostic, MCP-extensible CLI; six-framework machinery removed.
- **Revoke SSH key when forgetting a system** (#23) — opt-in, exact-match, in-place rewrite with backup, best-effort/logged.
- **Activity Monitor refresh while hidden** fix (#24).
- **Update check no longer offers downgrades** fix (#24).
- **clippy `--all-targets` clean** (#27).

No code changes here beyond the version bump — build and tests green at `v0.2.2`.

After merge I'll trigger the Release workflow (`workflow_dispatch`, tag `v0.2.2`) on `main` to build the prebuilt binaries and publish the GitHub Release.

https://claude.ai/code/session_01XzWmWBQr7Hqd8RJgkbuc26

---
_Generated by [Claude Code](https://claude.ai/code/session_01XzWmWBQr7Hqd8RJgkbuc26)_