### PR TITLE
fix: in-app update fallback could land in a $PATH-shadowed binary (0.2.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ carry user-visible feature work and the occasional breaking config change.
 
 ## [Unreleased]
 
+## [0.2.3] — 2026-06-13
+
+### Fixed
+- **In-app update could land in a shadowed binary**: when the fast path
+  (`install.sh`) failed — e.g. a brief network blip or racing a release's
+  asset upload — the updater fell back to `cargo install --git`, which writes to
+  cargo's default `~/.cargo/bin`. If that differs from the dir of the running
+  binary (e.g. a release install in `~/.local/bin`), the rebuilt binary landed
+  in a `$PATH`-shadowed location and the update silently appeared to do nothing.
+  The cargo fallback now targets the running binary's own `bin/` dir via
+  `--root`, so both update paths replace the binary the user actually runs.
+
 ## [0.2.2] — 2026-06-13
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1109,7 +1109,7 @@ checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tuiui"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "alacritty_terminal",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuiui"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 rust-version = "1.95"
 license = "MIT"

--- a/src/session.rs
+++ b/src/session.rs
@@ -3734,22 +3734,40 @@ fn update_command(branch: &str) -> String {
         .and_then(|p| p.parent().map(|d| d.to_path_buf()))
         .map(|d| d.display().to_string())
         .unwrap_or_else(|| "$HOME/.local/bin".into());
+    let root_flag = std::env::current_exe().map(|p| cargo_root_flag(&p)).unwrap_or_default();
     if branch == "main" {
         format!(
             "clear; echo 'Updating tuiui (latest release)…'; echo; \
 if TUIUI_BIN_DIR={dir} sh -c 'curl -fsSL {raw}/main/install.sh | sh'; then \
 echo; echo 'Reloading…'; tuiui reload; exit 0; \
-elif cargo install --git {repo} --force; then echo; echo 'Reloading…'; tuiui reload; exit 0; \
+elif cargo install --git {repo}{root_flag} --force; then echo; echo 'Reloading…'; tuiui reload; exit 0; \
 else echo 'Update failed — tuiui not reloaded.'; exec \"$SHELL\"; fi",
             dir = crate::systems::sh_quote(&exe_dir),
         )
     } else {
         format!(
             "clear; echo 'Updating tuiui (branch {branch})…'; echo; \
-if cargo install --git {repo} --branch {branch} --force; then \
+if cargo install --git {repo} --branch {branch}{root_flag} --force; then \
 echo; echo 'Reloading…'; tuiui reload; exit 0; \
 else echo 'Update failed — tuiui not reloaded.'; exec \"$SHELL\"; fi",
         )
+    }
+}
+
+/// The ` --root <dir>` flag that steers `cargo install` to the running
+/// binary's own `bin/` dir (its parent's parent — cargo appends `/bin` to the
+/// root), or an empty string when the binary isn't in a `bin/` dir (leaving
+/// cargo's default `~/.cargo/bin`). Co-locating the source build with the
+/// binary the user actually runs avoids landing a shadowed copy in a different
+/// dir, which would make the in-app update silently appear to do nothing.
+fn cargo_root_flag(exe: &std::path::Path) -> String {
+    match exe
+        .parent()
+        .filter(|d| d.file_name() == Some(std::ffi::OsStr::new("bin")))
+        .and_then(|d| d.parent())
+    {
+        Some(root) => format!(" --root {}", crate::systems::sh_quote(&root.display().to_string())),
+        None => String::new(),
     }
 }
 
@@ -3897,6 +3915,18 @@ mod tests {
         assert!(cmd.contains("tuiui reload"), "reloads on success");
         assert!(cmd.contains("exit 0"), "exits so the updater window auto-closes");
         assert!(!cmd.contains("--branch"), "main needs no branch flag");
+    }
+
+    #[test]
+    fn cargo_root_targets_the_running_bin_dir() {
+        use std::path::Path;
+        // A binary in a `bin/` dir → cargo is steered to the parent (it appends
+        // `/bin`), so the source build lands next to the running binary.
+        assert_eq!(cargo_root_flag(Path::new("/home/jay/.local/bin/tuiui")), " --root '/home/jay/.local'");
+        assert_eq!(cargo_root_flag(Path::new("/home/jay/.cargo/bin/tuiui")), " --root '/home/jay/.cargo'");
+        // Not in a `bin/` dir → no `--root` (leave cargo's default).
+        assert_eq!(cargo_root_flag(Path::new("/opt/tuiui/tuiui")), "");
+        assert_eq!(cargo_root_flag(Path::new("tuiui")), "");
     }
 
     #[test]


### PR DESCRIPTION
## The bug (found live)

The in-app updater's fast path installs the prebuilt release via `install.sh`, which honors `TUIUI_BIN_DIR` (set to the **running binary's own dir**) — so for a normal user it overwrites the exact file they run. But when that fast path **fails** (a network blip, or racing a release's asset upload — which is exactly what happened cutting 0.2.2), the updater falls back to:

```
cargo install --git <repo> --force
```

…which writes to cargo's **default `~/.cargo/bin`** — *not* `TUIUI_BIN_DIR`. If the running binary lives elsewhere (e.g. a release install in `~/.local/bin`, which is earlier on `$PATH`), the rebuilt binary lands in a **`$PATH`-shadowed** location and the update **silently appears to do nothing**. A maintainer hit this on a dual-install (`~/.local/bin` + `~/.cargo/bin`) box: `~/.cargo/bin` got the fresh build while the shadowing `~/.local/bin` copy kept running.

## The fix

Steer the cargo fallback to the running binary's own `bin/` dir via `cargo install --root <dir>` (cargo appends `/bin`). Applied to both the main-channel fallback and the dev-channel build. Extracted as a pure, unit-tested helper:

```rust
fn cargo_root_flag(exe: &Path) -> String  // " --root '/home/jay/.local'" for /home/jay/.local/bin/tuiui, "" if not a bin/ dir
```

Binaries not in a `bin/` dir leave cargo's default (no `--root`), so nothing regresses for unusual layouts.

## Tests

`cargo_root_targets_the_running_bin_dir` covers `~/.local/bin`, `~/.cargo/bin`, a non-`bin/` path, and a bare name. Full suite + `clippy --all-targets` green.

Cuts **0.2.3** (version bump + changelog). After merge I'll trigger the Release workflow for `v0.2.3`.

https://claude.ai/code/session_01XzWmWBQr7Hqd8RJgkbuc26

---
_Generated by [Claude Code](https://claude.ai/code/session_01XzWmWBQr7Hqd8RJgkbuc26)_