### PR TITLE
fix: port dev-branch hardening fixes to main (0.2.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ carry user-visible feature work and the occasional breaking config change.
 
 ## [Unreleased]
 
+## [0.2.4] — 2026-06-13
+
+### Fixed
+Robustness fixes from a code review of the networked seams — these had landed
+on the `dev` branch but never reached `main`, so they were absent from the
+0.2.x releases. Ported to `main`:
+- **Log-copy could crash the daemon**: copying a large (>200 KB) log whose
+  non-ASCII bytes straddled the tail cut sliced a string mid-UTF-8 and panicked.
+  The cut now advances to a char boundary first.
+- **Apphost reader resilience**: a single corrupted/blank protocol line used to
+  tear down the whole apphost connection (dropping every window's frame stream);
+  `recv` now logs-and-skips a bad line while still propagating genuine IO errors.
+- **Updater branch validation**: a hand-edited/typo'd `update_branch` flowed
+  into a shell command and a URL; it's now sanitized to a git-safe charset and
+  falls back to `main`.
+- **Control-socket lock resilience**: `apply_ctl` no longer holds the queue lock
+  across `core.apply` (which could block the control thread), and both lock
+  sites recover a poisoned lock so one panic can't wedge `tuiui launch/tile/
+  theme/msg`.
+- **Remote file-manager freeze bounded**: tightened SSH `ConnectTimeout` (4→3s)
+  and the frequent navigation ops (list/home → 5s) so an unreachable saved
+  system is a brief hitch, not a multi-second freeze.
+
 ## [0.2.3] — 2026-06-13
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1109,7 +1109,7 @@ checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tuiui"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "alacritty_terminal",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuiui"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 rust-version = "1.95"
 license = "MIT"

--- a/src/apphost/proto.rs
+++ b/src/apphost/proto.rs
@@ -105,18 +105,47 @@ pub fn send<T: Serialize, W: Write>(w: &mut W, msg: &T) -> std::io::Result<()> {
 }
 
 /// Read one newline-JSON message into `T`. `Ok(None)` on EOF.
+///
+/// A single unparseable (or blank) line is logged and SKIPPED rather than
+/// returned as an error: the reader loops break on `Err`, so without this a
+/// lone corrupted/truncated frame would tear down the whole apphost connection
+/// — dropping the frame stream for every window at once. Genuine IO errors
+/// from the socket still propagate (via `?`), so a dead peer breaks the loop
+/// instead of busy-spinning.
 pub fn recv<T: for<'de> Deserialize<'de>, R: BufRead>(r: &mut R) -> std::io::Result<Option<T>> {
-    let mut line = String::new();
-    if r.read_line(&mut line)? == 0 {
-        return Ok(None);
+    loop {
+        let mut line = String::new();
+        if r.read_line(&mut line)? == 0 {
+            return Ok(None); // EOF
+        }
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue; // tolerate blank/keepalive lines
+        }
+        match serde_json::from_str(trimmed) {
+            Ok(msg) => return Ok(Some(msg)),
+            Err(e) => crate::dbg_log(&format!("proto: skipping unparseable line ({e})")),
+        }
     }
-    let msg = serde_json::from_str(line.trim()).map_err(std::io::Error::other)?;
-    Ok(Some(msg))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn recv_skips_a_bad_line_and_keeps_the_stream_alive() {
+        // A corrupted/blank line between two valid frames must NOT end the
+        // stream (which would drop every window's frames at once).
+        let stream = b"not json at all\n\n{\"Gone\":{\"app\":7}}\n";
+        let mut r = std::io::BufReader::new(&stream[..]);
+        match recv::<HostEvt, _>(&mut r).unwrap().unwrap() {
+            HostEvt::Gone { app } => assert_eq!(app, 7, "recovered the next valid frame"),
+            other => panic!("expected Gone after skipping junk, got {other:?}"),
+        }
+        // Then clean EOF.
+        assert!(recv::<HostEvt, _>(&mut r).unwrap().is_none());
+    }
 
     #[test]
     fn roster_proto_round_trips_and_legacy_defaults_to_zero() {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -326,7 +326,15 @@ fn serve_client(
 /// If a control message has arrived, apply it to `core` (setting its
 /// shutdown/reload flag, which the loops already act on) and return `true`.
 fn apply_ctl(ctl: &Arc<AtomicU8>, queue: &CtlQueue, core: &mut SessionCore) -> bool {
-    for msg in queue.lock().unwrap().drain(..) {
+    // Drain under the lock into a local batch, then release it before applying:
+    // `core.apply` can be slow (spawns, theme reload), and holding the lock
+    // across it would block the control thread's push. `into_inner` recovers a
+    // poisoned lock so one panic can't wedge the control path forever.
+    let batch: Vec<ClientMsg> = {
+        let mut q = queue.lock().unwrap_or_else(|e| e.into_inner());
+        q.drain(..).collect()
+    };
+    for msg in batch {
         core.apply(msg);
     }
     match ctl.swap(CTL_NONE, Ordering::SeqCst) {
@@ -358,7 +366,7 @@ fn serve_control(listener: UnixListener, ctl: Arc<AtomicU8>, queue: CtlQueue) {
                 // CLI or the desktop assistant) queues for the render loop.
                 Ok(msg) => {
                     crate::dbg_log(&format!("ctl: queued {msg:?}"));
-                    queue.lock().unwrap().push(msg);
+                    queue.lock().unwrap_or_else(|e| e.into_inner()).push(msg);
                 }
                 Err(_) => {}
             }

--- a/src/fileops.rs
+++ b/src/fileops.rs
@@ -310,9 +310,17 @@ impl SshFs {
     }
 
     /// Run `cmd` through `sh -c` on the remote; `None` on failure/timeout.
+    ///
+    /// NOTE: these calls currently run synchronously on the daemon's render
+    /// loop (via `FileManager` inside `core.apply`), so an unreachable remote
+    /// briefly freezes the desktop — bounded by `ConnectTimeout` (3s) plus the
+    /// per-op `secs` budget. The frequent navigation ops (list/home) use short
+    /// budgets to keep that hitch small; copy/move keep a generous budget for
+    /// large transfers. The proper fix is to move remote FsOps off the render
+    /// loop (like the scp paste already is) — tracked as a follow-up.
     fn ssh(&self, cmd: &str, secs: u64) -> Option<String> {
         let port = self.port.map(|p| p.to_string());
-        let mut args: Vec<&str> = vec!["-o", "BatchMode=yes", "-o", "ConnectTimeout=4"];
+        let mut args: Vec<&str> = vec!["-o", "BatchMode=yes", "-o", "ConnectTimeout=3"];
         if let Some(p) = port.as_deref() {
             args.extend(["-p", p]);
         }
@@ -328,7 +336,7 @@ impl SshFs {
     /// The remote home directory (the browser's starting point), or `None`
     /// when the system is unreachable / key auth is not set up.
     pub fn remote_home(&self) -> Option<PathBuf> {
-        let home = self.ssh("pwd", 6)?;
+        let home = self.ssh("pwd", 5)?;
         let home = home.trim();
         (!home.is_empty()).then(|| PathBuf::from(home))
     }
@@ -345,7 +353,7 @@ impl SshFs {
 impl FsOps for SshFs {
     fn list(&self, dir: &Path, show_hidden: bool) -> io::Result<Vec<Entry>> {
         let cmd = format!("cd {} && LC_ALL=C ls -lA", Self::q(dir));
-        let out = self.ssh(&cmd, 8).ok_or_else(|| Self::err("list"))?;
+        let out = self.ssh(&cmd, 5).ok_or_else(|| Self::err("list"))?;
         let mut entries = Vec::new();
         for line in out.lines() {
             let Some((kind, size, name)) = parse_ls_line(line) else { continue };

--- a/src/logsview.rs
+++ b/src/logsview.rs
@@ -92,8 +92,15 @@ impl LogsView {
         let joined = self.lines.join("\n");
         let bytes = joined.as_bytes();
         let payload = if bytes.len() > MAX_COPY_BYTES {
-            // Cut on a line boundary inside the tail window.
-            let tail = &joined[joined.len() - MAX_COPY_BYTES..];
+            // Move the cut to a UTF-8 char boundary at/after the target offset —
+            // slicing at a raw byte index would PANIC mid-character, and log
+            // lines routinely hold non-ASCII (paths, app names, glyphs). Then
+            // trim the partial first line so we start on a whole line.
+            let mut cut = bytes.len() - MAX_COPY_BYTES;
+            while !joined.is_char_boundary(cut) {
+                cut += 1;
+            }
+            let tail = &joined[cut..];
             let start = tail.find('\n').map(|i| i + 1).unwrap_or(0);
             tail[start..].to_string()
         } else {
@@ -180,6 +187,23 @@ mod tests {
         assert!(s.len() <= super::MAX_COPY_BYTES);
         assert!(s.starts_with("line "), "starts on a whole line: {:?}", &s[..20]);
         assert!(v.status().contains("copied"));
+    }
+
+    #[test]
+    fn copy_payload_does_not_panic_on_multibyte_at_the_cut() {
+        // Lines full of multi-byte UTF-8 ('✦' is 3 bytes) so the ~200KB-from-end
+        // cut is overwhelmingly likely to land mid-character — must not panic.
+        let line = "✦".repeat(200); // 600 bytes/line
+        let mut v = LogsView {
+            lines: (0..2000).map(|i| format!("{i} {line}")).collect(),
+            scroll: 0,
+            follow: true,
+            status: String::new(),
+            page: std::cell::Cell::new(10),
+        };
+        let s = v.copy_payload(); // would panic on a non-boundary byte slice
+        assert!(s.len() <= super::MAX_COPY_BYTES);
+        assert!(std::str::from_utf8(s.as_bytes()).is_ok(), "valid UTF-8 out");
     }
 
     #[test]

--- a/src/session.rs
+++ b/src/session.rs
@@ -3720,12 +3720,30 @@ fn take_reopen_hint() -> Option<u8> {
     code
 }
 
+/// Accept only well-formed git branch names; anything else falls back to
+/// `main`. The branch comes from `config.update_branch`, which a hand-edited
+/// config (or a typo) could set to junk — and it's interpolated into both a
+/// shell command and a URL below, so a stray quote/space would otherwise
+/// produce a broken updater run rather than a clean fallback.
+fn sanitize_branch(branch: &str) -> String {
+    let ok = !branch.is_empty()
+        && branch.len() <= 100
+        && branch
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '/' | '.'))
+        && !branch.starts_with('-')
+        && !branch.contains("..");
+    if ok { branch.to_string() } else { "main".to_string() }
+}
+
 /// The shell command that updates tuiui and reloads. On `main` it prefers the
 /// prebuilt release binary (a fast download via `install.sh`, jumping straight
 /// to the latest release), falling back to a source build; on any other branch
 /// (the dev channel) it builds that branch from git. On success it reloads and
 /// EXITS so the updater window auto-closes; only a failure drops to a shell.
 fn update_command(branch: &str) -> String {
+    let branch = sanitize_branch(branch);
+    let branch = branch.as_str();
     let repo = crate::REPO_URL;
     let raw = "https://raw.githubusercontent.com/jaylfc/tuiui";
     // Keep the new binary where the running one lives (cargo bin vs ~/.local/bin).
@@ -3808,6 +3826,8 @@ fn compat_dialog_buttons(w: i32, h: i32) -> (Rect, Rect) {
 ///   we compare the installed commit against the branch tip and report short
 ///   commit hashes.
 fn check_for_updates(branch: &str) -> String {
+    let branch = sanitize_branch(branch);
+    let branch = branch.as_str();
     let repo = crate::REPO_URL.trim_start_matches("https://github.com/");
     let get_json = |path: &str| -> Option<serde_json::Value> {
         let url = format!("https://api.github.com/repos/{repo}/{path}");
@@ -3935,6 +3955,22 @@ mod tests {
         assert!(cmd.contains("cargo install --git"), "dev builds from source");
         assert!(cmd.contains("--branch dev"), "on the dev branch: {cmd}");
         assert!(!cmd.contains("install.sh"), "no prebuilt release off main");
+    }
+
+    #[test]
+    fn junk_branch_falls_back_to_main() {
+        // A hand-edited / typo'd config branch must never leak shell syntax or a
+        // broken ref into the updater command or the check URL.
+        for junk in ["x; rm -rf ~", "a b", "evil'", "--force", "..", ""] {
+            assert_eq!(sanitize_branch(junk), "main", "rejected: {junk:?}");
+            let cmd = update_command(junk);
+            assert!(cmd.contains("install.sh"), "junk → the safe main path: {cmd}");
+            assert!(!cmd.contains("rm -rf"), "no injected payload survives: {cmd}");
+        }
+        // Legitimate branch names are preserved.
+        for ok in ["dev", "main", "feature/x", "release-1.2", "v0.2.0"] {
+            assert_eq!(sanitize_branch(ok), ok);
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Context

While confirming an earlier session's work, I found that its review-hardening fixes were merged to **`dev`** (PRs #18/#19/#20) but **`dev` was never merged to `main`** — and every release since (0.2.1–0.2.3) was cut from `main`. So these fixes, **including a live daemon crash**, were absent from what users run. `dev` and `main` have since diverged substantially, so rather than a blind merge I **ported the surgical hardening fixes** onto `main` (main's code still matched the pre-fix state, so they applied cleanly).

## Ported (each with its test)

- **Log-copy crash (real)** — `logsview::copy_payload` sliced the tail at a raw byte offset; a non-ASCII char straddling the ~200 KB cut panicked the daemon. Now snaps to a UTF-8 char boundary. Test uses 3-byte glyphs across the cut.
- **Apphost reader resilience** — `proto::recv` logs-and-skips a corrupted/blank line instead of tearing down the whole apphost connection (which dropped every window's frame stream); genuine IO errors still propagate.
- **Updater branch validation** — `sanitize_branch()` restricts `update_branch` to a git-safe charset and falls back to `main`, so a hand-edited/typo'd value can't leak into the updater shell command or the check URL.
- **Control-socket lock** — `apply_ctl` drains under the lock then releases **before** `core.apply`; both lock sites recover a poisoned lock via `into_inner`.
- **Remote-FM freeze bounded** — SSH `ConnectTimeout` 4→3s and list/home budgets 8/6→5s.

## Not ported

The dock-context-menu clamp (#20) is **N/A** — that menu is a **dev-only feature** not yet on `main`. That (and the rest of dev's feature delta, e.g. the dock right-click menu) is the **separate feature-reconciliation** coming next.

Cuts **0.2.4**. Build + tests + `clippy --all-targets` green. After merge I'll trigger the `v0.2.4` release, then start the feature merge.

https://claude.ai/code/session_01XzWmWBQr7Hqd8RJgkbuc26

---
_Generated by [Claude Code](https://claude.ai/code/session_01XzWmWBQr7Hqd8RJgkbuc26)_