### PR TITLE
release: 0.2.6 (dock context menu + activity-monitor follow-ups)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ carry user-visible feature work and the occasional breaking config change.
 
 ## [Unreleased]
 
+## [0.2.6] — 2026-06-13
+
 ### Added
 - **Dock right-click context menu**: right-click a dock pill for Minimise /
   Maximise / Close / Reset size. Grouped pills target the group's focused

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1109,7 +1109,7 @@ checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tuiui"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "alacritty_terminal",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuiui"
-version = "0.2.5"
+version = "0.2.6"
 edition = "2021"
 rust-version = "1.95"
 license = "MIT"


### PR DESCRIPTION
## Release 0.2.6

Version-bump PR that ships the work merged since 0.2.5:
- **Dock right-click context menu** (#32) — Minimise / Maximise / Close / Reset size.
- **Activity-monitor / apphost follow-ups** (#33) — `tuiui ps`/`kill-app` roster drain, `kill-app all` safe-by-default, `HostEvt::Spawned` `pid` field (`PROTO_VERSION → 2`, additive), `RemoteAppHost` cmd/args stash.

Bumps `Cargo.toml`/`Cargo.lock` to `0.2.6` and rolls the `[Unreleased]` notes into a `[0.2.6]` section. **Merging this auto-cuts the `v0.2.6` release** via the version-bump pipeline (builds the four platform binaries, tags from this commit, publishes) — no manual tag or dispatch needed.

https://claude.ai/code/session_01XzWmWBQr7Hqd8RJgkbuc26

---
_Generated by [Claude Code](https://claude.ai/code/session_01XzWmWBQr7Hqd8RJgkbuc26)_