### PR TITLE
fix: in-app update could succeed without changing the running version (0.2.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ carry user-visible feature work and the occasional breaking config change.
 
 ## [Unreleased]
 
+## [0.2.7] — 2026-06-13
+
+### Fixed
+- **In-app update could "succeed" without changing the running version**: the
+  updater reloads by running a bare `tuiui reload`, but it runs in a
+  non-interactive `sh -lc` whose PATH may not include the install dir
+  (`~/.local/bin` is added by interactive shell config, not a login `sh`). When
+  `tuiui` wasn't found, `install.sh` still wrote the new binary but the daemon
+  never restarted onto it — so the version never moved and the update appeared
+  to fail every time. The updater now reloads via the **absolute path** of the
+  freshly-installed binary (`{install_dir}/tuiui reload`), removing the PATH
+  dependency.
+
+### Changed
+- **The updater now logs to `~/tuiui-debug.log`**: the in-app update runs in a
+  window whose output was otherwise lost. Update checks, the install request,
+  and each install step (install.sh / cargo fallback / reload / failure) now
+  leave breadcrumbs in the debug log, so a failed update is visible in the log
+  users paste.
+
 ## [0.2.6] — 2026-06-13
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1109,7 +1109,7 @@ checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tuiui"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "alacritty_terminal",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuiui"
-version = "0.2.6"
+version = "0.2.7"
 edition = "2021"
 rust-version = "1.95"
 license = "MIT"

--- a/src/session.rs
+++ b/src/session.rs
@@ -703,6 +703,10 @@ impl SessionCore {
             Some(crate::settings::SettingsAction::CheckUpdates) => {
                 let branch = self.cfg.update_branch.clone();
                 let msg = check_for_updates(&branch);
+                crate::dbg_log(&format!(
+                    "update: check (branch {branch}, running v{}) -> {msg}",
+                    crate::VERSION
+                ));
                 if let Some(s) = self.focused_settings_mut() {
                     s.set_update_status(msg);
                 }
@@ -715,6 +719,12 @@ impl SessionCore {
                 // reload, so the user isn't dumped back on the bare desktop.
                 write_reopen_hint(Ui_SETTINGS_UPDATES);
                 let cmd = update_command(&self.cfg.update_branch);
+                crate::dbg_log(&format!(
+                    "update: install requested (branch {}, running v{}, exe {:?}); running in a window",
+                    self.cfg.update_branch,
+                    crate::VERSION,
+                    std::env::current_exe().ok()
+                ));
                 self.launch("update tuiui".into(), "sh".into(), vec!["-lc".into(), cmd]);
             }
             None => {}
@@ -3856,21 +3866,38 @@ fn update_command(branch: &str) -> String {
         .map(|d| d.display().to_string())
         .unwrap_or_else(|| "$HOME/.local/bin".into());
     let root_flag = std::env::current_exe().map(|p| cargo_root_flag(&p)).unwrap_or_default();
+    let dir = crate::systems::sh_quote(&exe_dir);
+    // Reload via the freshly-installed binary's ABSOLUTE path, not a bare
+    // `tuiui`. The updater runs in a non-interactive `sh -lc`, whose PATH may
+    // not include the install dir (~/.local/bin is added by interactive zsh
+    // config, not a login `sh`). If `tuiui reload` isn't found, the install
+    // still succeeds but the daemon never restarts onto the new binary — so
+    // the running version never changes and the update appears to "keep
+    // failing". install.sh lands the binary in `exe_dir` (TUIUI_BIN_DIR), and
+    // the cargo `--root` fallback targets the same dir, so `{exe_dir}/tuiui` is
+    // the new binary in both paths.
+    let reload = crate::systems::sh_quote(&format!("{exe_dir}/tuiui"));
+    // Append each step to ~/tuiui-debug.log (same file as dbg_log) so a failed
+    // update is visible in the log the user pastes — the install runs in a
+    // window whose output is otherwise lost.
+    let log = "\"$HOME/tuiui-debug.log\"";
     if branch == "main" {
         format!(
             "clear; echo 'Updating tuiui (latest release)…'; echo; \
+echo \"update: install -> {dir}\" >> {log}; \
 if TUIUI_BIN_DIR={dir} sh -c 'curl -fsSL {raw}/main/install.sh | sh'; then \
-echo; echo 'Reloading…'; tuiui reload; exit 0; \
-elif cargo install --git {repo}{root_flag} --force; then echo; echo 'Reloading…'; tuiui reload; exit 0; \
-else echo 'Update failed — tuiui not reloaded.'; exec \"$SHELL\"; fi",
-            dir = crate::systems::sh_quote(&exe_dir),
+echo \"update: install.sh ok; reloading via {reload}\" >> {log}; echo; echo 'Reloading…'; {reload} reload; exit 0; \
+elif cargo install --git {repo}{root_flag} --force; then \
+echo \"update: cargo fallback ok; reloading via {reload}\" >> {log}; echo; echo 'Reloading…'; {reload} reload; exit 0; \
+else echo \"update: FAILED (install.sh and cargo both failed)\" >> {log}; echo 'Update failed — tuiui not reloaded.'; exec \"$SHELL\"; fi",
         )
     } else {
         format!(
             "clear; echo 'Updating tuiui (branch {branch})…'; echo; \
+echo \"update: cargo install (branch {branch})\" >> {log}; \
 if cargo install --git {repo} --branch {branch}{root_flag} --force; then \
-echo; echo 'Reloading…'; tuiui reload; exit 0; \
-else echo 'Update failed — tuiui not reloaded.'; exec \"$SHELL\"; fi",
+echo \"update: cargo ok; reloading via {reload}\" >> {log}; echo; echo 'Reloading…'; {reload} reload; exit 0; \
+else echo \"update: FAILED (cargo branch {branch})\" >> {log}; echo 'Update failed — tuiui not reloaded.'; exec \"$SHELL\"; fi",
         )
     }
 }
@@ -4060,7 +4087,9 @@ mod tests {
         let cmd = update_command("main");
         assert!(cmd.contains("install.sh"), "fast path is the prebuilt release: {cmd}");
         assert!(cmd.contains("cargo install --git"), "with a source fallback");
-        assert!(cmd.contains("tuiui reload"), "reloads on success");
+        assert!(cmd.contains("/tuiui' reload"), "reloads via the installed binary's absolute path: {cmd}");
+        assert!(!cmd.contains("; tuiui reload"), "must not rely on PATH-resolving a bare `tuiui`: {cmd}");
+        assert!(cmd.contains("tuiui-debug.log"), "logs each step to the debug log");
         assert!(cmd.contains("exit 0"), "exits so the updater window auto-closes");
         assert!(!cmd.contains("--branch"), "main needs no branch flag");
     }


### PR DESCRIPTION
## The bug

An in-app update is a chain: **check → `install.sh` → `tuiui reload` → daemon respawns the new binary.** We proved `install.sh` works perfectly on macOS/Apple-Silicon (downloads `v0.2.6`, installs to `~/.local/bin/tuiui`, runs — no signing/PATH issues). So the failure is the **reload step**:

The updater runs in a non-interactive `sh -lc`, and reloads with a **bare `tuiui reload`**. That relies on `tuiui` being on the shell's PATH — but `~/.local/bin` is typically added by *interactive* shell config (zsh), not a login `sh`. When `tuiui` isn't found, `install.sh` still writes the new binary, but **the daemon never restarts onto it** — so the running version never changes and the update appears to "keep failing," every time, while the new binary sits on disk.

## The fix

- **Reload via the absolute path** of the freshly-installed binary — `{install_dir}/tuiui reload` — removing the PATH dependency. `install.sh` (`TUIUI_BIN_DIR`) and the `cargo --root` fallback both land the binary in that dir, so it's correct on both paths.
- **Log the updater to `~/tuiui-debug.log`**: update checks, the install request (branch / running version / exe path), and each step (install.sh / cargo / reload / failure) now leave breadcrumbs. The update runs in a window whose output was otherwise lost — this is why the log was useless for diagnosing it. Now a failed update is visible in the log users paste.

App-safe: this only changes how the reload is invoked and adds logging — no apphost restart, no `MIN_COMPAT` change, so live apps/windows are preserved.

## Release

Bumps to **0.2.7**; merging auto-cuts the release. `cargo test` + `cargo clippy --all-targets` clean (updated the updater test to assert the absolute-path reload + logging).

https://claude.ai/code/session_01XzWmWBQr7Hqd8RJgkbuc26

---
_Generated by [Claude Code](https://claude.ai/code/session_01XzWmWBQr7Hqd8RJgkbuc26)_