### PR TITLE
release: 0.2.8 (switchable assistant agent)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ carry user-visible feature work and the occasional breaking config change.
 
 ## [Unreleased]
 
+## [0.2.8] — 2026-06-13
+
 ### Added
 - **Switchable assistant agent**: Settings → Assistant now has an **Agent** row
   that flips the ✦ panel between the two supported CLIs — **opencode** (default)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1109,7 +1109,7 @@ checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tuiui"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "alacritty_terminal",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuiui"
-version = "0.2.7"
+version = "0.2.8"
 edition = "2021"
 rust-version = "1.95"
 license = "MIT"


### PR DESCRIPTION
## Release 0.2.8

Version-bump PR that ships the work merged since 0.2.7:
- **Switchable assistant agent** (#37) — Settings → Assistant flips the ✦ panel between **opencode** and **hermes**.

Bumps `Cargo.toml`/`Cargo.lock` to `0.2.8` and rolls `[Unreleased]` into `[0.2.8]`. **Merging auto-cuts the `v0.2.8` release** via the version-bump pipeline.

This is also the **first release built on the 0.2.7 in-app-update fix** — updating from 0.2.7 → 0.2.8 exercises the absolute-path reload and writes `update:` breadcrumbs to `~/tuiui-debug.log`.

https://claude.ai/code/session_01XzWmWBQr7Hqd8RJgkbuc26

---
_Generated by [Claude Code](https://claude.ai/code/session_01XzWmWBQr7Hqd8RJgkbuc26)_