### PR TITLE
fix: debug log no longer wipes the update trace on reload + instrument the reload seam (0.2.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ carry user-visible feature work and the occasional breaking config change.
 
 ## [Unreleased]
 
+## [0.2.9] — 2026-06-13
+
+### Changed
+- **The debug log now survives a reload, and records the version + binary** of
+  every daemon start. `dbg_init` previously *truncated* `~/tuiui-debug.log` on
+  each daemon startup — so an in-app update that reloaded the daemon wiped its
+  own trace, leaving the log useless for diagnosing update failures. It now
+  appends a richer banner (`v<version>, git <sha>, exe <path>`) and the reload
+  → respawn seam is logged on both sides (`daemon: reload — exiting…`,
+  `client: daemon reload — …respawning`, `daemon: spawning <exe> --daemon`).
+  An update attempt now leaves a complete, persistent trace: the install
+  steps, the reload, and the **post-update version** in the next banner — so a
+  "version never changed" failure is finally visible in one log.
+
 ## [0.2.8] — 2026-06-13
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1109,7 +1109,7 @@ checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tuiui"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "alacritty_terminal",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuiui"
-version = "0.2.8"
+version = "0.2.9"
 edition = "2021"
 rust-version = "1.95"
 license = "MIT"

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -127,6 +127,8 @@ pub fn run() -> std::io::Result<()> {
     let _ = std::fs::remove_file(&ctl_path);
     if !reloading {
         core.shutdown(); // full stop: kills apps + tells the apphost to exit
+    } else {
+        crate::dbg_log("daemon: reload — exiting to restart, apphost preserved");
     }
     // On reload we just drop `core` (its RemoteAppHost disconnects); the apphost
     // keeps running so the next frontend can restore the apps.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,19 +80,19 @@ pub fn dbg_log(msg: &str) {
     }
 }
 
-/// Truncate `~/tuiui-debug.log` and write a session-start banner. Called once
-/// at daemon startup so each run starts with a clean, readable log.
+/// Append a session-start banner to `~/tuiui-debug.log` (running version, git
+/// sha, and binary path). Called once at daemon startup.
+///
+/// Deliberately APPENDS rather than truncates: when an in-app update reloads
+/// the daemon, the previous session's trace (the `update:` steps, the reload)
+/// must survive alongside the new banner so the *whole* update is visible in
+/// one log — truncating here is what made update failures invisible (the new
+/// daemon wiped the evidence). `dbg_log`'s size cap keeps the file bounded.
 pub fn dbg_init() {
-    let Some(home) = dirs::home_dir() else { return };
-    use std::io::Write;
-    if let Ok(mut f) = std::fs::OpenOptions::new()
-        .create(true)
-        .write(true)
-        .truncate(true)
-        .open(home.join("tuiui-debug.log"))
-    {
-        let _ = writeln!(f, "=== tuiui debug session start (git {}) ===", GIT_SHA);
-    }
+    let exe = std::env::current_exe()
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|_| "?".into());
+    dbg_log(&format!("=== tuiui session start (v{VERSION}, git {GIT_SHA}, exe {exe}) ==="));
 }
 pub mod protocol;
 pub mod daemon;

--- a/src/main.rs
+++ b/src/main.rs
@@ -128,6 +128,7 @@ fn attach(spawn_if_missing: bool) -> std::io::Result<()> {
             tuiui::client::ClientExit::Reload => {
                 // The daemon is restarting; wait briefly for the old socket to
                 // drop, then loop to spawn/connect the fresh daemon.
+                tuiui::dbg_log("client: daemon reload — waiting for old socket to drop, then respawning");
                 for _ in 0..100 {
                     if UnixStream::connect(socket_path()).is_err() { break; }
                     std::thread::sleep(Duration::from_millis(20));
@@ -193,6 +194,7 @@ fn run_switch(spec: &tuiui::systems::SwitchSpec) {
 /// client exiting (and SSH disconnects).
 fn spawn_daemon() -> std::io::Result<()> {
     let exe = std::env::current_exe()?;
+    tuiui::dbg_log(&format!("daemon: spawning {} --daemon", exe.display()));
     std::process::Command::new(exe)
         .arg("--daemon")
         .stdin(std::process::Stdio::null())


### PR DESCRIPTION
## Deep-investigation instrumentation for the still-stuck Settings update

The 0.2.7 breadcrumbs stop at `reloading via …`, so the **reload → respawn seam is a blind spot** — exactly where "install works but the version never changes" lives. Worse, I found why the **log itself was useless**:

### The log was wiping its own evidence
`dbg_init` **truncated** `~/tuiui-debug.log` on *every* daemon startup. An in-app update reloads the daemon → the new daemon truncates the log → the `update:` steps and the reload are **erased**, leaving only a fresh banner. That's why the log "doesn't look helpful." It now **appends** (size-capped) instead, so a reload's full trace survives in one file.

### Now traceable end-to-end
- Banner records **version + git sha + binary path** per daemon start (`=== tuiui session start (v0.2.9, git …, exe …) ===`) — so the **post-update version** is right there.
- `daemon: spawning <exe> --daemon` — reveals **which binary** the client respawns (the crux: stale vs updated).
- `client: daemon reload — …respawning` and `daemon: reload — exiting to restart` — confirm both sides of the reload actually happen.

After this, an update attempt leaves a complete, persistent chain:
```
update: install -> '…/.local/bin'
update: install.sh ok; reloading via '…/.local/bin/tuiui'
daemon: reload — exiting to restart, apphost preserved
client: daemon reload — …respawning
daemon: spawning '…/.local/bin/tuiui' --daemon
=== tuiui session start (v0.2.9 → vNEW, git …, exe …) ===
```
If the final banner shows the **old** version/sha → the respawn ran a stale binary (the bug). If it shows the **new** one → the update worked and "stuck" is a repaint/UI issue. Either way we'll know precisely.

`cargo test` + `cargo clippy --all-targets` clean. Bumps to **0.2.9**; merging auto-cuts the release.

## How to use it
1. Get onto 0.2.9 via the manual one-liner (reliable): `curl -fsSL https://raw.githubusercontent.com/jaylfc/tuiui/main/install.sh | sh && tuiui reload`
2. Trigger the update from Settings.
3. Paste the tail of `~/tuiui-debug.log` — it'll pinpoint the exact failing step.

https://claude.ai/code/session_01XzWmWBQr7Hqd8RJgkbuc26

---
_Generated by [Claude Code](https://claude.ai/code/session_01XzWmWBQr7Hqd8RJgkbuc26)_