### PR TITLE
docs: sync assistant + updater docs with shipped 0.2.7-0.2.8 changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,11 +104,13 @@ real terminal              composites frames, routes input    survives UI reload
 of truth for everything the in-app agent is told — embedded via
 `include_str!`, stamped into `~/.local/share/tuiui/assistant/` at launch as
 `AGENTS.md`, the context file the assistant reads on startup. tuiui
-standardises on the **opencode** CLI (`DEFAULT_AGENT`); `assistant_command`
-in config.toml can point the panel at a different binary, but there is no
-per-framework branching — opencode is model-agnostic and MCP-extensible, so
-broader OS/computer-use control is added via MCP servers in opencode's own
-config rather than by adding frameworks here.
+standardises on the **opencode** CLI (`DEFAULT_AGENT`), with **hermes** as a
+supported alternative (`AGENTS`) — Settings → Assistant switches between the
+two, stored in `assistant_command`, which can also point the panel at any
+other binary by hand. There is no per-framework branching beyond that
+switch — opencode is model-agnostic and MCP-extensible, so broader
+OS/computer-use control is added via MCP servers in opencode's own config
+rather than by adding frameworks here.
 
 ## Tests
 

--- a/agent/README.md
+++ b/agent/README.md
@@ -6,16 +6,18 @@ into the assistant's working directory (`~/.local/share/tuiui/assistant/`) on
 every launch, with live placeholders (host name, saved systems, version)
 filled in.
 
-tuiui standardises on the **opencode** CLI. Its working directory is forced as
-the agent's cwd, and the pack is written there as `AGENTS.md` — the context file
-opencode reads on startup:
+tuiui standardises on the **opencode** CLI, with **hermes** as a supported
+alternative (switch between them in **Settings → Assistant**). Its working
+directory is forced as the agent's cwd, and the pack is written there as
+`AGENTS.md` — the context file opencode (or hermes) reads on startup:
 
 | File written at launch | Read by                  |
 |------------------------|--------------------------|
-| `AGENTS.md`            | opencode (the assistant) |
+| `AGENTS.md`            | opencode / hermes (the assistant) |
 
-(`assistant_command` in config.toml can point the panel at a different binary,
-but the briefing is always stamped as `AGENTS.md`.)
+(`assistant_command` in config.toml stores the switch and can also point the
+panel at any other binary by hand, but the briefing is always stamped as
+`AGENTS.md`.)
 
 Editing a file here changes what the agent is told, after a rebuild.
 

--- a/agent/README.md
+++ b/agent/README.md
@@ -9,11 +9,13 @@ filled in.
 tuiui standardises on the **opencode** CLI, with **hermes** as a supported
 alternative (switch between them in **Settings → Assistant**). Its working
 directory is forced as the agent's cwd, and the pack is written there as
-`AGENTS.md` — the context file opencode (or hermes) reads on startup:
+`AGENTS.md` — the context file opencode reads on startup (hermes is assumed
+compatible with the same convention, but that isn't verified against its own
+docs):
 
 | File written at launch | Read by                  |
 |------------------------|--------------------------|
-| `AGENTS.md`            | opencode / hermes (the assistant) |
+| `AGENTS.md`            | opencode (confirmed); hermes (assumed) |
 
 (`assistant_command` in config.toml stores the switch and can also point the
 panel at any other binary by hand, but the briefing is always stamped as

--- a/agent/TROUBLESHOOTING.md
+++ b/agent/TROUBLESHOOTING.md
@@ -37,5 +37,7 @@ cargo test           # 300+ tests must stay green
 
 Make the fix, keep the existing code style, add a regression test, and open a
 pull request against that repository. The user installs your merged fix
-in-app via Settings → Updates (which runs `cargo install --git {{REPO}}` and
-reloads with apps intact).
+in-app via Settings → Updates: the **main** channel downloads the latest
+prebuilt release (fast), falling back to `cargo install --git {{REPO}}`; the
+**dev** channel always builds from source (`cargo install --git {{REPO}}
+--branch dev`). Either way it reloads with apps intact.


### PR DESCRIPTION
## What's stale and what's fixed

- **`CLAUDE.md`** — "The AI assistant" section said tuiui "standardises on the opencode CLI" with "no per-framework branching," predating the 0.2.8 switchable-agent feature (#37). `src/assistant.rs` has had `AGENTS: &[&str] = &["opencode", "hermes"]` and a Settings → Assistant toggle since 0.2.8; the doc now says so.
- **`agent/README.md`** — same stale "opencode CLI" framing, with no mention of the hermes alternative or the Settings switch. Updated to match.
- **`agent/TROUBLESHOOTING.md`** — "Fixing tuiui itself" described the updater as always running `cargo install --git {{REPO}}`, predating the 0.2.7 change (`update_command` in `src/session.rs`) where the **main** channel downloads the prebuilt release via `install.sh` first, falling back to `cargo install --git`, and only the **dev** channel builds from source directly.

No behavior changes — docs only. Verified `cargo build`, `cargo clippy --all-targets` (0 warnings), and `cargo test` all pass on this branch.

## Repo activity (informational, no action taken)

- **PR #15** (Wayland compositor, `kilo-code-bot`) has been open since 2026-06-12 with repeated bot review cycles (5 CRITICAL findings in the latest pass: undeclared `wayland-compositor` feature, `run_compositor()` stubbed to always error, restart-looping systemd service, inert `pgrep` pattern) and no CI status (state: pending, 0 checks). Already tracked by issue #34 with a clear rebase plan — no new action needed.
- **Issue #1** (catalog-update bot, 6 new TUIs from awesome-tuis) is open and actionable whenever someone wants to run the catalog-gen script.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NxpvnhiK9VSGnE32MbCR6r)_