### PR TITLE
docs: fix stale opencode-only Roadmap line for the AI assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ Design docs and the slice-by-slice plan live in [`docs/superpowers/`](docs/super
 - **✅ Logs viewer:** launcher → tuiui → Logs; `c` copies the log to the host clipboard via OSC 52.
 - **✅ Scrollback:** the mouse wheel pages back through any app window's history.
 - **✅ Versioned releases + update channels:** semver in `Cargo.toml`, a `CHANGELOG`, and a main/dev channel switcher in Settings → Updates (main installs prebuilt releases fast; dev builds from source).
-- **✅ AI assistant:** the ✦ chat panel/window — the opencode CLI (model-agnostic, MCP-extensible), the repo `agent/` briefing pack, desktop control via the `tuiui` CLI, cross-machine awareness.
+- **✅ AI assistant:** the ✦ chat panel/window — switchable between the opencode CLI (model-agnostic, MCP-extensible) and hermes (Settings → Assistant), the repo `agent/` briefing pack, desktop control via the `tuiui` CLI, cross-machine awareness.
 - **Slice 6 — GUI/Wayland mode** (host real GUI apps; audio/video streaming to the client) — plus a parked idea: a fullscreen **browser PWA** of tuiui (multiple simultaneous frontends on one apphost).
 - **Slice 7 — Standalone "TUI-OS" app** (bundle a GPU terminal + tuiui into a fullscreen app).
 


### PR DESCRIPTION
## What's stale and what's fixed

- **`README.md` — Roadmap**: the "✅ AI assistant" checklist line still said
  "the opencode CLI (model-agnostic, MCP-extensible)" with no mention of the
  hermes alternative — predating the 0.2.8 switchable-agent feature (#37).
  The "What works today" bullet a few sections up (and the `config.toml`
  comments) already document the Settings → Assistant opencode/hermes
  switch; the Roadmap line was the one place still out of sync. Updated to
  match.

Docs-only, one line. No code touched, so the clippy/test gate doesn't apply.

## Repo activity (informational, no action taken)

- **PR #41** (docs: sync assistant + updater docs with shipped 0.2.7-0.2.8
  changes) is open, unmerged, and already has a clean Kilo Code Review
  ("No Issues Found | Recommendation: Merge") — it covers `CLAUDE.md`,
  `agent/README.md`, and `agent/TROUBLESHOOTING.md`. This PR is additive to
  that one (different file) and does not conflict with it.
- **PR #15** (Wayland compositor, opened by `kilo-code-bot`) remains open
  since 2026-06-12 with no CI status and prior CRITICAL bot-review findings.
  Already tracked by issue #34 with a rebase plan — no new action taken.
- **Issue #1** (catalog-update bot, 6 new TUIs from awesome-tuis) is still
  open and actionable whenever someone wants to run the catalog-gen script.
- **Issue #34** (Wayland compositor tracking issue) — unchanged, still
  accurately describes the plan to rebase PR #15.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PfBaFTHbunVH1ZuhtR7kWu)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the roadmap to clarify that the chat panel/window can switch between the opencode CLI and hermes.
  * Added the Settings → Assistant path for changing this option.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->