### PR TITLE
store: sync catalog with awesome-tuis — 10 new apps, fix a name typo

### DIFF
--- a/assets/catalog.json
+++ b/assets/catalog.json
@@ -77,6 +77,13 @@
   "homepage": "https://herdr.dev"
  },
  {
+  "name": "Hermes",
+  "bin": "hermes",
+  "category": "AI",
+  "description": "Nous Research's self-improving AI agent: creates skills from experience and builds a persistent model of its user. Chat TUI via hermes --tui.",
+  "homepage": "https://hermes-agent.nousresearch.com"
+ },
+ {
   "name": "Kilo Code",
   "bin": "kilo",
   "category": "AI",
@@ -96,6 +103,13 @@
   "category": "AI",
   "description": "A coding agent with the IDE wired in (the omp CLI): 40+ model providers, dozens of built-in tools, and LSP/DAP integration for read/edit/run workflows in the terminal.",
   "homepage": "https://omp.sh"
+ },
+ {
+  "name": "OpenClaw",
+  "bin": "openclaw",
+  "category": "AI",
+  "description": "Your own personal AI assistant — self-hosted gateway answering on WhatsApp/Telegram/Slack/Discord and more; terminal chat via openclaw tui.",
+  "homepage": "https://openclaw.ai"
  },
  {
   "name": "opencode",
@@ -124,6 +138,13 @@
   "category": "AI",
   "description": "Open-source AI coding agent that runs in your terminal, optimized for Qwen series models.",
   "homepage": "https://github.com/QwenLM/qwen-code"
+ },
+ {
+  "name": "smallcode",
+  "bin": "smallcode",
+  "category": "AI",
+  "description": "AI coding agent optimized for small local LLMs (8B-35B) via Ollama/LM Studio/llama.cpp, with optional escalation to cloud models.",
+  "homepage": "https://github.com/Doorman11991/smallcode"
  },
  {
   "name": "AdGuardian-Term",
@@ -362,6 +383,13 @@
   "category": "Dashboards",
   "description": "Heroku Terminal User Interface",
   "homepage": "https://github.com/PierreKieffer/htui"
+ },
+ {
+  "name": "hwatch",
+  "bin": "hwatch",
+  "category": "Dashboards",
+  "description": "A modern alternative to watch that records command output history and provides interactive diff views, scrolling, filtering, JSON logging, and hooks.",
+  "homepage": "https://github.com/blacknon/hwatch"
  },
  {
   "name": "hwinfo-tui",
@@ -735,18 +763,18 @@
   "homepage": "https://github.com/bfly123/claude_code_bridge"
  },
  {
+  "name": "Claude Code Usage Monitor",
+  "bin": "claude-monitor",
+  "category": "Development",
+  "description": "Monitor Claude token usage",
+  "homepage": "https://github.com/Maciek-roboblog/Claude-Code-Usage-Monitor"
+ },
+ {
   "name": "Close Mongo Ops Manager",
   "bin": "close-mongo-ops-manager",
   "category": "Development",
   "description": "Monitor and kill MongoDB operations",
   "homepage": "https://github.com/closeio/close-mongo-ops-manager"
- },
- {
-  "name": "Cloud Code Usage Monitor",
-  "bin": "claude-monitor",
-  "category": "Development",
-  "description": "Monitor Claude token usage",
-  "homepage": "https://github.com/Maciek-roboblog/Claude-Code-Usage-Monitor"
  },
  {
   "name": "cnTUI",
@@ -847,6 +875,13 @@
   "homepage": "https://github.com/anistark/feluda"
  },
  {
+  "name": "freeze",
+  "bin": "freeze",
+  "category": "Development",
+  "description": "Generate images of code and terminal output.",
+  "homepage": "https://github.com/charmbracelet/freeze"
+ },
+ {
   "name": "Froggit",
   "bin": "froggit",
   "category": "Development",
@@ -915,6 +950,13 @@
   "category": "Development",
   "description": "Terminal interface for viewing git repositories",
   "homepage": "https://github.com/rgburke/grv"
+ },
+ {
+  "name": "gum",
+  "bin": "gum",
+  "category": "Development",
+  "description": "A tool for glamorous shell scripts (prompts, menus, spinners).",
+  "homepage": "https://github.com/charmbracelet/gum"
  },
  {
   "name": "harlequin",
@@ -987,6 +1029,13 @@
   "homepage": "https://codeberg.org/wvhulle/lean-tui"
  },
  {
+  "name": "litecli",
+  "bin": "litecli",
+  "category": "Development",
+  "description": "SQLite CLI with auto-completion and syntax highlighting.",
+  "homepage": "https://github.com/dbcli/litecli"
+ },
+ {
   "name": "LogLens",
   "bin": "loglens",
   "category": "Development",
@@ -1022,6 +1071,13 @@
   "homepage": "https://github.com/arimxyer/models"
  },
  {
+  "name": "mycli",
+  "bin": "mycli",
+  "category": "Development",
+  "description": "MySQL/MariaDB CLI with auto-completion and syntax highlighting.",
+  "homepage": "https://github.com/dbcli/mycli"
+ },
+ {
   "name": "nap",
   "bin": "nap",
   "category": "Development",
@@ -1041,6 +1097,13 @@
   "category": "Development",
   "description": "OPC UA client TUI with real-time oscilloscope view for industrial automation",
   "homepage": "https://github.com/SquareWaveSystems/opcilloscope"
+ },
+ {
+  "name": "pgcli",
+  "bin": "pgcli",
+  "category": "Development",
+  "description": "Postgres CLI with auto-completion and syntax highlighting.",
+  "homepage": "https://github.com/dbcli/pgcli"
  },
  {
   "name": "play",
@@ -1158,7 +1221,7 @@
   "name": "snips.sh",
   "bin": "snips.sh",
   "category": "Development",
-  "description": "\u2702\ufe0f passwordless, anonymous SSH-powered pastebin with a human-friendly TUI and web UI",
+  "description": "✂️ passwordless, anonymous SSH-powered pastebin with a human-friendly TUI and web UI",
   "homepage": "https://github.com/robherley/snips.sh"
  },
  {
@@ -1477,11 +1540,25 @@
   "homepage": "https://github.com/TomasTomecek/sen"
  },
  {
+  "name": "SwarmCLI",
+  "bin": "swarmcli",
+  "category": "Docker/LXC/K8s",
+  "description": "Swarm Management at the speed of thought — with real-time log streaming, instant shell access to containers, seamless port forwarding, and on-demand secret reveal capabilities, giving you full control over your Docker Swarm without breaking your flow.",
+  "homepage": "https://github.com/Eldara-Tech/swarmcli"
+ },
+ {
   "name": "talos-pilot",
   "bin": "talos-pilot",
   "category": "Docker/LXC/K8s",
   "description": "TUI for Talos Linux providing real-time node monitoring, log streaming, and various diagnostics",
   "homepage": "https://github.com/handfish/talos-pilot"
+ },
+ {
+  "name": "amp",
+  "bin": "amp",
+  "category": "Editors",
+  "description": "A complete text editor for your terminal",
+  "homepage": "https://github.com/jmacdonald/amp"
  },
  {
   "name": "C-Edit",
@@ -1503,6 +1580,13 @@
   "category": "Editors",
   "description": "A simple text editor. Pays homage to the classic MS-DOS Editor.",
   "homepage": "https://github.com/microsoft/edit"
+ },
+ {
+  "name": "flow-control",
+  "bin": "flow",
+  "category": "Editors",
+  "description": "A lightning-fast, feature-rich text editor written in Zig",
+  "homepage": "https://github.com/neurocyte/flow"
  },
  {
   "name": "Fresh",
@@ -1559,6 +1643,13 @@
   "category": "Editors",
   "description": "A modern and intuitive terminal-based text editor",
   "homepage": "https://github.com/zyedidia/micro"
+ },
+ {
+  "name": "microNeo",
+  "bin": "microneo",
+  "category": "Editors",
+  "description": "A fork of Micro with in-place Markdown rendering — view and edit in the same window",
+  "homepage": "https://github.com/sollawen/microNeo"
  },
  {
   "name": "nino",
@@ -1683,7 +1774,7 @@
   "name": "nnn",
   "bin": "nnn",
   "category": "File Managers",
-  "description": "n\u00b3 The unorthodox terminal file manager.",
+  "description": "n³ The unorthodox terminal file manager.",
   "homepage": "https://github.com/jarun/nnn"
  },
  {
@@ -1748,6 +1839,13 @@
   "category": "File Managers",
   "description": "Blazing fast terminal file manager written in Rust, based on async I/O.",
   "homepage": "https://github.com/sxyazi/yazi"
+ },
+ {
+  "name": "ytreenova",
+  "bin": "ytnova",
+  "category": "File Managers",
+  "description": "The XTree style file manager Unix should have had all along.",
+  "homepage": "https://github.com/robkam/ytreenova"
  },
  {
   "name": "awkaster",
@@ -2149,6 +2247,13 @@
   "homepage": "https://github.com/erikjuhani/basalt"
  },
  {
+  "name": "concord",
+  "bin": "concord",
+  "category": "Messaging",
+  "description": "A feature-rich TUI client for Discord",
+  "homepage": "https://github.com/chojs23/concord"
+ },
+ {
   "name": "Devzat",
   "bin": "devzat",
   "category": "Messaging",
@@ -2189,6 +2294,13 @@
   "category": "Messaging",
   "description": "Signal Messenger client for terminal",
   "homepage": "https://github.com/boxdot/gurk-rs"
+ },
+ {
+  "name": "himalaya",
+  "bin": "himalaya",
+  "category": "Messaging",
+  "description": "CLI/TUI to manage emails (IMAP/SMTP, multi-account).",
+  "homepage": "https://github.com/pimalaya/himalaya"
  },
  {
   "name": "iamb",
@@ -2497,6 +2609,20 @@
   "category": "Miscellaneous",
   "description": "TUI for managing distrobox containers",
   "homepage": "https://github.com/phanirithvij/distrobox-tui"
+ },
+ {
+  "name": "dua",
+  "bin": "dua",
+  "category": "Miscellaneous",
+  "description": "Fast interactive disk-usage analyzer and cleaner.",
+  "homepage": "https://github.com/Byron/dua-cli"
+ },
+ {
+  "name": "dust",
+  "bin": "dust",
+  "category": "Miscellaneous",
+  "description": "A more intuitive, visual version of du (disk usage).",
+  "homepage": "https://github.com/bootandy/dust"
  },
  {
   "name": "ec2-instance-selector",
@@ -3290,6 +3416,13 @@
   "homepage": "https://github.com/zorig/valvefm"
  },
  {
+  "name": "vhs",
+  "bin": "vhs",
+  "category": "Multimedia",
+  "description": "Write terminal GIFs as code — scriptable session recorder.",
+  "homepage": "https://github.com/charmbracelet/vhs"
+ },
+ {
   "name": "viu",
   "bin": "viu",
   "category": "Multimedia",
@@ -3531,7 +3664,7 @@
   "name": "hygg",
   "bin": "hygg",
   "category": "Productivity",
-  "description": "\ud83d\udcda Simplifying the way you read. Minimalistic Vim-like TUI document reader.",
+  "description": "📚 Simplifying the way you read. Minimalistic Vim-like TUI document reader.",
   "homepage": "https://github.com/kruserr/hygg"
  },
  {
@@ -3584,6 +3717,13 @@
   "homepage": "https://github.com/pimutils/khal"
  },
  {
+  "name": "khard",
+  "bin": "khard",
+  "category": "Productivity",
+  "description": "Console CardDAV address book and contact manager.",
+  "homepage": "https://github.com/lucc/khard"
+ },
+ {
   "name": "LazySSH",
   "bin": "lazyssh",
   "category": "Productivity",
@@ -3605,6 +3745,13 @@
   "homepage": "https://github.com/longbridge/longbridge-terminal"
  },
  {
+  "name": "lssh",
+  "bin": "lssh",
+  "category": "Productivity",
+  "description": "A terminal-native remote access suite for SSH workflows, including interactive host selection, parallel commands, mux workspaces, file transfer, sync, diff, forwarding, and multi-host monitoring.",
+  "homepage": "https://github.com/blacknon/lssh"
+ },
+ {
   "name": "mcfly",
   "bin": "mcfly",
   "category": "Productivity",
@@ -3624,6 +3771,13 @@
   "category": "Productivity",
   "description": "Workspace and session management for terminal environments",
   "homepage": "https://github.com/GianlucaP106/mynav"
+ },
+ {
+  "name": "nb",
+  "bin": "nb",
+  "category": "Productivity",
+  "description": "Plain-text note-taking, bookmarking, and knowledge base.",
+  "homepage": "https://github.com/xwmx/nb"
  },
  {
   "name": "nless",
@@ -3724,18 +3878,18 @@
   "homepage": "https://github.com/andmarti1424/sc-im"
  },
  {
-  "name": "SheetsUI",
-  "bin": "sheetsui",
-  "category": "Productivity",
-  "description": "A console based spreadsheet application",
-  "homepage": "https://github.com/zaphar/sheetsui"
- },
- {
   "name": "sheets",
   "bin": "sheets",
   "category": "Productivity",
   "description": "Terminal-based spreadsheet tool backed by CSV files.",
   "homepage": "https://github.com/maaslalani/sheets"
+ },
+ {
+  "name": "SheetsUI",
+  "bin": "sheetsui",
+  "category": "Productivity",
+  "description": "A console based spreadsheet application",
+  "homepage": "https://github.com/zaphar/sheetsui"
  },
  {
   "name": "slides",
@@ -3850,6 +4004,20 @@
   "homepage": "https://github.com/topydo/topydo"
  },
  {
+  "name": "trx",
+  "bin": "trx",
+  "category": "Productivity",
+  "description": "Terminal package manager with fuzzy search and keyboard-driven package discovery.",
+  "homepage": "https://github.com/pie-314/trx"
+ },
+ {
+  "name": "ttm",
+  "bin": "ttm",
+  "category": "Productivity",
+  "description": "SSH bookmark manager with Bubble Tea TUI — connect, manage and sync via Gist",
+  "homepage": "https://github.com/vst93/ttm"
+ },
+ {
   "name": "ttyplot",
   "bin": "ttyplot",
   "category": "Productivity",
@@ -3906,11 +4074,25 @@
   "homepage": "https://github.com/magiblot/tvterm"
  },
  {
+  "name": "vdirsyncer",
+  "bin": "vdirsyncer",
+  "category": "Productivity",
+  "description": "Synchronize calendars and contacts (CalDAV/CardDAV).",
+  "homepage": "https://github.com/pimutils/vdirsyncer"
+ },
+ {
   "name": "Visidata",
   "bin": "visidata",
   "category": "Productivity",
   "description": "A terminal spreadsheet multitool for discovering and arranging data",
   "homepage": "https://github.com/saulpw/visidata"
+ },
+ {
+  "name": "wordgrinder",
+  "bin": "wordgrinder",
+  "category": "Productivity",
+  "description": "Distraction-free Unicode word processor for the terminal.",
+  "homepage": "https://github.com/davidgiven/wordgrinder"
  },
  {
   "name": "zeit",
@@ -4184,117 +4366,5 @@
   "category": "Web",
   "description": "A text-mode WWW browser",
   "homepage": "https://github.com/tats/w3m"
- },
- {
-  "name": "wordgrinder",
-  "bin": "wordgrinder",
-  "category": "Productivity",
-  "description": "Distraction-free Unicode word processor for the terminal.",
-  "homepage": "https://github.com/davidgiven/wordgrinder"
- },
- {
-  "name": "himalaya",
-  "bin": "himalaya",
-  "category": "Messaging",
-  "description": "CLI/TUI to manage emails (IMAP/SMTP, multi-account).",
-  "homepage": "https://github.com/pimalaya/himalaya"
- },
- {
-  "name": "khard",
-  "bin": "khard",
-  "category": "Productivity",
-  "description": "Console CardDAV address book and contact manager.",
-  "homepage": "https://github.com/lucc/khard"
- },
- {
-  "name": "vdirsyncer",
-  "bin": "vdirsyncer",
-  "category": "Productivity",
-  "description": "Synchronize calendars and contacts (CalDAV/CardDAV).",
-  "homepage": "https://github.com/pimutils/vdirsyncer"
- },
- {
-  "name": "nb",
-  "bin": "nb",
-  "category": "Productivity",
-  "description": "Plain-text note-taking, bookmarking, and knowledge base.",
-  "homepage": "https://github.com/xwmx/nb"
- },
- {
-  "name": "gum",
-  "bin": "gum",
-  "category": "Development",
-  "description": "A tool for glamorous shell scripts (prompts, menus, spinners).",
-  "homepage": "https://github.com/charmbracelet/gum"
- },
- {
-  "name": "vhs",
-  "bin": "vhs",
-  "category": "Multimedia",
-  "description": "Write terminal GIFs as code \u2014 scriptable session recorder.",
-  "homepage": "https://github.com/charmbracelet/vhs"
- },
- {
-  "name": "freeze",
-  "bin": "freeze",
-  "category": "Development",
-  "description": "Generate images of code and terminal output.",
-  "homepage": "https://github.com/charmbracelet/freeze"
- },
- {
-  "name": "dust",
-  "bin": "dust",
-  "category": "Miscellaneous",
-  "description": "A more intuitive, visual version of du (disk usage).",
-  "homepage": "https://github.com/bootandy/dust"
- },
- {
-  "name": "dua",
-  "bin": "dua",
-  "category": "Miscellaneous",
-  "description": "Fast interactive disk-usage analyzer and cleaner.",
-  "homepage": "https://github.com/Byron/dua-cli"
- },
- {
-  "name": "pgcli",
-  "bin": "pgcli",
-  "category": "Development",
-  "description": "Postgres CLI with auto-completion and syntax highlighting.",
-  "homepage": "https://github.com/dbcli/pgcli"
- },
- {
-  "name": "mycli",
-  "bin": "mycli",
-  "category": "Development",
-  "description": "MySQL/MariaDB CLI with auto-completion and syntax highlighting.",
-  "homepage": "https://github.com/dbcli/mycli"
- },
- {
-  "name": "litecli",
-  "bin": "litecli",
-  "category": "Development",
-  "description": "SQLite CLI with auto-completion and syntax highlighting.",
-  "homepage": "https://github.com/dbcli/litecli"
- },
- {
-  "name": "smallcode",
-  "bin": "smallcode",
-  "category": "AI",
-  "description": "AI coding agent optimized for small local LLMs (8B-35B) via Ollama/LM Studio/llama.cpp, with optional escalation to cloud models.",
-  "homepage": "https://github.com/Doorman11991/smallcode"
- },
- {
-  "name": "Hermes",
-  "bin": "hermes",
-  "category": "AI",
-  "description": "Nous Research's self-improving AI agent: creates skills from experience and builds a persistent model of its user. Chat TUI via hermes --tui.",
-  "homepage": "https://hermes-agent.nousresearch.com"
- },
- {
-  "name": "OpenClaw",
-  "bin": "openclaw",
-  "category": "AI",
-  "description": "Your own personal AI assistant \u2014 self-hosted gateway answering on WhatsApp/Telegram/Slack/Discord and more; terminal chat via openclaw tui.",
-  "homepage": "https://openclaw.ai"
  }
 ]

--- a/assets/recipes.json
+++ b/assets/recipes.json
@@ -169,8 +169,8 @@
    "windows"
   ],
   "requires_cwd": true,
-  "verified": true,
-  "tip": "First run: `claude` walks you through logging in with your Anthropic account (or set ANTHROPIC_API_KEY)."
+  "tip": "First run: `claude` walks you through logging in with your Anthropic account (or set ANTHROPIC_API_KEY).",
+  "verified": true
  },
  "Claude Code Bridge": {
   "install": "pip install claude-code-bridge",
@@ -182,6 +182,15 @@
   ],
   "verified": true
  },
+ "Claude Code Usage Monitor": {
+  "install": "pipx install claude-monitor",
+  "method": "pipx",
+  "os": [
+   "macos",
+   "linux"
+  ],
+  "verified": true
+ },
  "Close Mongo Ops Manager": {
   "install": "pipx install close-mongo-ops-manager",
   "method": "pipx",
@@ -189,15 +198,6 @@
    "macos",
    "linux",
    "windows"
-  ],
-  "verified": true
- },
- "Cloud Code Usage Monitor": {
-  "install": "pipx install claude-monitor",
-  "method": "pipx",
-  "os": [
-   "macos",
-   "linux"
   ],
   "verified": true
  },
@@ -489,6 +489,16 @@
   "requires_cwd": true,
   "verified": true
  },
+ "Hermes": {
+  "install": "curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash",
+  "method": "script",
+  "os": [
+   "macos",
+   "linux"
+  ],
+  "tip": "First run: `hermes model` in a shell to add providers and API keys (or `hermes setup --portal`). Config lives in ~/.hermes/config.yaml. Chat with `hermes --tui`.",
+  "verified": true
+ },
  "HumBLE Explorer": {
   "install": "pipx install humble-explorer",
   "method": "pipx",
@@ -544,8 +554,8 @@
    "windows"
   ],
   "requires_cwd": true,
-  "verified": true,
-  "tip": "First run: type /connect inside kilo (or `kilo auth login`) to add a provider. A free Kilo account includes hosted models; BYOK and Ollama also work."
+  "tip": "First run: type /connect inside kilo (or `kilo auth login`) to add a provider. A free Kilo account includes hosted models; BYOK and Ollama also work.",
+  "verified": true
  },
  "Kyanos": {
   "install": "tar xvf kyanos_vx.x.x_linux_amd64.tar.gz && sudo mv kyanos /usr/local/bin/",
@@ -673,6 +683,17 @@
    "macos",
    "linux"
   ],
+  "verified": true
+ },
+ "OpenClaw": {
+  "install": "curl -fsSL https://openclaw.ai/install.sh | bash",
+  "method": "script",
+  "os": [
+   "macos",
+   "linux",
+   "windows"
+  ],
+  "tip": "First run: `openclaw onboard --install-daemon` in a shell — picks a provider, adds API keys, starts the gateway. Needs Node 22.19+. Chat with `openclaw tui`.",
   "verified": true
  },
  "OpenHands": {
@@ -870,6 +891,11 @@
    "macos",
    "linux"
   ],
+  "verified": true
+ },
+ "SwarmCLI": {
+  "install": "git clone https://github.com/Eldara-Tech/swarmcli.git && cd swarmcli && go install .",
+  "method": "source",
   "verified": true
  },
  "Systemd-manager-tui": {
@@ -1147,6 +1173,15 @@
  },
  "alpine": {
   "install": "brew install alpine",
+  "method": "brew",
+  "os": [
+   "macos",
+   "linux"
+  ],
+  "verified": true
+ },
+ "amp": {
+  "install": "brew install amp",
   "method": "brew",
   "os": [
    "macos",
@@ -1696,6 +1731,15 @@
   ],
   "verified": true
  },
+ "concord": {
+  "install": "brew install concord",
+  "method": "brew",
+  "os": [
+   "macos",
+   "linux"
+  ],
+  "verified": true
+ },
  "cruise": {
   "install": "brew tap cruise-org/homebrew-tap && brew install --cask cruise",
   "method": "brew",
@@ -1993,12 +2037,32 @@
   ],
   "verified": true
  },
+ "dua": {
+  "install": "cargo install dua-cli",
+  "method": "cargo",
+  "os": [
+   "macos",
+   "linux",
+   "windows"
+  ],
+  "verified": true
+ },
  "ducker": {
   "install": "brew install ducker",
   "method": "brew",
   "os": [
    "macos",
    "linux"
+  ],
+  "verified": true
+ },
+ "dust": {
+  "install": "cargo install du-dust",
+  "method": "cargo",
+  "os": [
+   "macos",
+   "linux",
+   "windows"
   ],
   "verified": true
  },
@@ -2179,6 +2243,15 @@
   ],
   "verified": true
  },
+ "flow-control": {
+  "install": "brew install flow-control",
+  "method": "brew",
+  "os": [
+   "macos",
+   "linux"
+  ],
+  "verified": true
+ },
  "fml": {
   "install": "git clone https://github.com/wick3dr0se/fml && cd fml && cp fml /usr/local/bin",
   "method": "script",
@@ -2199,6 +2272,15 @@
  },
  "framework-tool-tui": {
   "install": "brew install framework-tool-tui",
+  "method": "brew",
+  "os": [
+   "macos",
+   "linux"
+  ],
+  "verified": true
+ },
+ "freeze": {
+  "install": "brew install charmbracelet/tap/freeze",
   "method": "brew",
   "os": [
    "macos",
@@ -2289,18 +2371,18 @@
   ],
   "verified": true
  },
- "gif-for-cli": {
-  "install": "pipx install gif-for-cli",
-  "method": "pipx",
+ "ghui": {
+  "install": "brew install kitlangton/tap/ghui",
+  "method": "brew",
   "os": [
    "macos",
    "linux"
   ],
   "verified": true
  },
- "ghui": {
-  "install": "brew install kitlangton/tap/ghui",
-  "method": "brew",
+ "gif-for-cli": {
+  "install": "pipx install gif-for-cli",
+  "method": "pipx",
   "os": [
    "macos",
    "linux"
@@ -2474,6 +2556,15 @@
   ],
   "verified": true
  },
+ "gum": {
+  "install": "brew install gum",
+  "method": "brew",
+  "os": [
+   "macos",
+   "linux"
+  ],
+  "verified": true
+ },
  "gurk-rs": {
   "install": "brew install gurk",
   "method": "brew",
@@ -2557,6 +2648,16 @@
   ],
   "verified": true
  },
+ "himalaya": {
+  "install": "cargo install himalaya --locked",
+  "method": "cargo",
+  "os": [
+   "macos",
+   "linux",
+   "windows"
+  ],
+  "verified": true
+ },
  "hledger-ui": {
   "install": "brew install hledger",
   "method": "brew",
@@ -2602,6 +2703,15 @@
    "macos",
    "linux",
    "windows"
+  ],
+  "verified": true
+ },
+ "hwatch": {
+  "install": "brew install hwatch",
+  "method": "brew",
+  "os": [
+   "macos",
+   "linux"
   ],
   "verified": true
  },
@@ -2855,6 +2965,15 @@
   ],
   "verified": true
  },
+ "khard": {
+  "install": "pipx install khard",
+  "method": "pipx",
+  "os": [
+   "macos",
+   "linux"
+  ],
+  "verified": true
+ },
  "kilo": {
   "install": "git clone https://github.com/antirez/kilo.git && cd kilo && make && sudo cp kilo /usr/local/bin/",
   "method": "source",
@@ -3001,6 +3120,15 @@
   ],
   "verified": true
  },
+ "litecli": {
+  "install": "brew install litecli",
+  "method": "brew",
+  "os": [
+   "macos",
+   "linux"
+  ],
+  "verified": true
+ },
  "llm": {
   "install": "pipx install llm",
   "method": "pipx",
@@ -3059,6 +3187,11 @@
    "linux",
    "windows"
   ],
+  "verified": true
+ },
+ "lssh": {
+  "install": "go install github.com/blacknon/lssh/cmd/lssh@latest",
+  "method": "go",
   "verified": true
  },
  "mac-cleanup-go": {
@@ -3208,6 +3341,15 @@
   ],
   "verified": true
  },
+ "microNeo": {
+  "install": "curl -fsSL https://raw.githubusercontent.com/sollawen/microNeo/master/tools/install.sh | sh",
+  "method": "script",
+  "os": [
+   "macos",
+   "linux"
+  ],
+  "verified": true
+ },
  "minesweep-rs": {
   "install": "cargo install minesweep",
   "method": "cargo",
@@ -3311,6 +3453,15 @@
   ],
   "verified": true
  },
+ "mycli": {
+  "install": "brew install mycli",
+  "method": "brew",
+  "os": [
+   "macos",
+   "linux"
+  ],
+  "verified": true
+ },
  "mynav": {
   "install": "curl -fsSL https://raw.githubusercontent.com/GianlucaP106/mynav/main/install.bash | bash",
   "method": "script",
@@ -3340,6 +3491,15 @@
  },
  "nap": {
   "install": "brew install nap",
+  "method": "brew",
+  "os": [
+   "macos",
+   "linux"
+  ],
+  "verified": true
+ },
+ "nb": {
+  "install": "brew install nb",
   "method": "brew",
   "os": [
    "macos",
@@ -3622,8 +3782,8 @@
    "windows"
   ],
   "requires_cwd": true,
-  "verified": true,
-  "tip": "First run: `opencode auth login` to pick a provider and add a key \u2014 local models via Ollama are supported."
+  "tip": "First run: `opencode auth login` to pick a provider and add a key — local models via Ollama are supported.",
+  "verified": true
  },
  "openmux": {
   "install": "npm install -g openmux",
@@ -3720,6 +3880,15 @@
   "install": "pip install pdiary",
   "method": "pip",
   "os": [
+   "linux"
+  ],
+  "verified": true
+ },
+ "pgcli": {
+  "install": "brew install pgcli",
+  "method": "brew",
+  "os": [
+   "macos",
    "linux"
   ],
   "verified": true
@@ -4211,6 +4380,15 @@
   ],
   "verified": true
  },
+ "sfm": {
+  "install": "git clone https://github.com/afify/sfm && cd sfm && make && make install",
+  "method": "source",
+  "os": [
+   "linux",
+   "macos"
+  ],
+  "verified": true
+ },
  "sheets": {
   "install": "go install github.com/maaslalani/sheets@latest",
   "method": "go",
@@ -4218,15 +4396,6 @@
    "macos",
    "linux",
    "windows"
-  ],
-  "verified": true
- },
- "sfm": {
-  "install": "git clone https://github.com/afify/sfm && cd sfm && make && make install",
-  "method": "source",
-  "os": [
-   "linux",
-   "macos"
   ],
   "verified": true
  },
@@ -4266,6 +4435,18 @@
    "linux",
    "windows"
   ],
+  "verified": true
+ },
+ "smallcode": {
+  "install": "npm install -g smallcode",
+  "method": "npm",
+  "os": [
+   "macos",
+   "linux",
+   "windows"
+  ],
+  "requires_cwd": true,
+  "tip": "Needs a local OpenAI-compatible server (Ollama, LM Studio, llama.cpp). Set SMALLCODE_MODEL and SMALLCODE_BASE_URL in a .env in your project, or run /provider inside smallcode. Node 18+.",
   "verified": true
  },
  "smassh": {
@@ -5000,8 +5181,22 @@
   ],
   "verified": true
  },
+ "trx": {
+  "install": "curl -fsSL https://trx.pidev.tech/install.sh | sh",
+  "method": "script",
+  "verified": true
+ },
  "try-rs": {
   "install": "brew install try-rs",
+  "method": "brew",
+  "os": [
+   "macos",
+   "linux"
+  ],
+  "verified": true
+ },
+ "ttm": {
+  "install": "brew install vst93/tap/ttm",
   "method": "brew",
   "os": [
    "macos",
@@ -5271,6 +5466,24 @@
   ],
   "verified": true
  },
+ "vdirsyncer": {
+  "install": "pipx install vdirsyncer",
+  "method": "pipx",
+  "os": [
+   "macos",
+   "linux"
+  ],
+  "verified": true
+ },
+ "vhs": {
+  "install": "brew install vhs",
+  "method": "brew",
+  "os": [
+   "macos",
+   "linux"
+  ],
+  "verified": true
+ },
  "violet": {
   "install": "go install github.com/braheezy/violet/cmd/violet@latest",
   "method": "go",
@@ -5416,6 +5629,15 @@
   ],
   "verified": true
  },
+ "wordgrinder": {
+  "install": "brew install wordgrinder",
+  "method": "brew",
+  "os": [
+   "macos",
+   "linux"
+  ],
+  "verified": true
+ },
  "wttr.in": {
   "install": "git clone https://github.com/chubin/wttr.in && cd wttr.in && bash build.sh build",
   "method": "source",
@@ -5480,6 +5702,14 @@
   ],
   "verified": true
  },
+ "ytreenova": {
+  "install": "git clone https://github.com/robkam/ytreenova.git && cd ytreenova && make && sudo make install",
+  "method": "source",
+  "os": [
+   "linux"
+  ],
+  "verified": true
+ },
  "ytui-music": {
   "install": "git clone https://github.com/sudipghimire533/ytui-music && cd ytui-music && git submodule init && MPV_BUILD=mpv-build/ cargo build --all --release --features build_libmpv",
   "method": "source",
@@ -5534,158 +5764,5 @@
    "linux"
   ],
   "verified": true
- },
- "wordgrinder": {
-  "install": "brew install wordgrinder",
-  "method": "brew",
-  "os": [
-   "macos",
-   "linux"
-  ],
-  "verified": true
- },
- "himalaya": {
-  "install": "cargo install himalaya --locked",
-  "method": "cargo",
-  "os": [
-   "macos",
-   "linux",
-   "windows"
-  ],
-  "verified": true
- },
- "khard": {
-  "install": "pipx install khard",
-  "method": "pipx",
-  "os": [
-   "macos",
-   "linux"
-  ],
-  "verified": true
- },
- "vdirsyncer": {
-  "install": "pipx install vdirsyncer",
-  "method": "pipx",
-  "os": [
-   "macos",
-   "linux"
-  ],
-  "verified": true
- },
- "nb": {
-  "install": "brew install nb",
-  "method": "brew",
-  "os": [
-   "macos",
-   "linux"
-  ],
-  "verified": true
- },
- "gum": {
-  "install": "brew install gum",
-  "method": "brew",
-  "os": [
-   "macos",
-   "linux"
-  ],
-  "verified": true
- },
- "vhs": {
-  "install": "brew install vhs",
-  "method": "brew",
-  "os": [
-   "macos",
-   "linux"
-  ],
-  "verified": true
- },
- "freeze": {
-  "install": "brew install charmbracelet/tap/freeze",
-  "method": "brew",
-  "os": [
-   "macos",
-   "linux"
-  ],
-  "verified": true
- },
- "dust": {
-  "install": "cargo install du-dust",
-  "method": "cargo",
-  "os": [
-   "macos",
-   "linux",
-   "windows"
-  ],
-  "verified": true
- },
- "dua": {
-  "install": "cargo install dua-cli",
-  "method": "cargo",
-  "os": [
-   "macos",
-   "linux",
-   "windows"
-  ],
-  "verified": true
- },
- "pgcli": {
-  "install": "brew install pgcli",
-  "method": "brew",
-  "os": [
-   "macos",
-   "linux"
-  ],
-  "verified": true
- },
- "mycli": {
-  "install": "brew install mycli",
-  "method": "brew",
-  "os": [
-   "macos",
-   "linux"
-  ],
-  "verified": true
- },
- "litecli": {
-  "install": "brew install litecli",
-  "method": "brew",
-  "os": [
-   "macos",
-   "linux"
-  ],
-  "verified": true
- },
- "smallcode": {
-  "install": "npm install -g smallcode",
-  "method": "npm",
-  "verified": true,
-  "os": [
-   "macos",
-   "linux",
-   "windows"
-  ],
-  "requires_cwd": true,
-  "tip": "Needs a local OpenAI-compatible server (Ollama, LM Studio, llama.cpp). Set SMALLCODE_MODEL and SMALLCODE_BASE_URL in a .env in your project, or run /provider inside smallcode. Node 18+."
- },
- "Hermes": {
-  "install": "curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash",
-  "method": "script",
-  "verified": true,
-  "os": [
-   "macos",
-   "linux"
-  ],
-  "tip": "First run: `hermes model` in a shell to add providers and API keys (or `hermes setup --portal`). Config lives in ~/.hermes/config.yaml. Chat with `hermes --tui`."
- },
- "OpenClaw": {
-  "install": "curl -fsSL https://openclaw.ai/install.sh | bash",
-  "method": "script",
-  "verified": true,
-  "os": [
-   "macos",
-   "linux",
-   "windows"
-  ],
-  "tip": "First run: `openclaw onboard --install-daemon` in a shell \u2014 picks a provider, adds API keys, starts the gateway. Needs Node 22.19+. Chat with `openclaw tui`."
  }
 }

--- a/scripts/gen_catalog.py
+++ b/scripts/gen_catalog.py
@@ -17,6 +17,16 @@ from pathlib import Path
 # "Libraries" are TUI frameworks, not runnable apps — excluded from the store.
 EXCLUDE = {"Libraries"}
 
+# Individual entries excluded from the store (lowercased names): either not
+# installable apps, or already curated in the catalog under another name.
+EXCLUDE_APPS = {
+    "termui",         # Go widget library, not a runnable app
+    "iconicfonts",    # patched-font collection, not a runnable app
+    "learnbyexample", # collection of separate tutorial apps, no single binary
+    "codex",          # already curated as "Codex" (AI category)
+    "crush",          # already curated as "Crush" (AI category)
+}
+
 # Binary names that differ from the project name (improves detection).
 BIN_OVERRIDES = {
     "bottom": "btm",
@@ -27,6 +37,8 @@ BIN_OVERRIDES = {
     "trippy": "trip",
     "superfile": "spf",
     "tig": "tig",
+    "flow-control": "flow",
+    "ytreenova": "ytnova",
 }
 
 
@@ -53,6 +65,8 @@ def main() -> int:
         if not m or not category or category in EXCLUDE:
             continue
         name = m.group(1).strip()
+        if name.lower() in EXCLUDE_APPS:
+            continue
         if name.lower() in seen:
             continue
         seen.add(name.lower())


### PR DESCRIPTION
Closes #1.

## What's in

Adds the installable apps from the weekly catalog check (issue #1, latest sweep listed 17), each with a **verified install recipe**, keeping the catalog's 624/624 app↔recipe coverage:

| App | Category | Recipe | Verified how |
|---|---|---|---|
| hwatch | Dashboards | `brew install hwatch` | formula confirmed in homebrew-core |
| SwarmCLI | Docker/LXC/K8s | clone + `go install .` | module is named `swarmcli` (not a github path), so `go install ...@latest` can't work — recipe follows the README |
| amp | Editors | `brew install amp` | formula confirmed in homebrew-core (homepage amp.rs — this is jmacdonald's editor, distinct from the AI-category "Amp") |
| flow-control | Editors | `brew install flow-control` | formula confirmed in homebrew-core; bin is `flow` |
| microNeo | Editors | official one-line install script | script installs bin `microneo` to `~/.local/bin` |
| ytreenova | File Managers | clone + `make && sudo make install` | Makefile confirmed; bin is `ytnova`, Linux-only per README |
| concord | Messaging | `brew install concord` | formula confirmed in homebrew-core |
| lssh | Productivity | `go install github.com/blacknon/lssh/cmd/lssh@latest` | go.mod module path confirmed |
| trx | Productivity | official install script | documented one-liner from the README |
| ttm | Productivity | `brew install vst93/tap/ttm` | documented tap, same pattern as existing tap recipes |

## What the checker flagged that is NOT a new app

- **Claude Code Usage Monitor** — already in the catalog, but under the typo'd name **"Cloud Code Usage Monitor"**; renamed (catalog + recipes key), keeping its existing verified `pipx install claude-monitor` recipe. The checker matches by exact name, so the typo made it re-flag every week.
- **codex / crush** — already curated as **Codex** and **Crush** in the AI category (case-different names).
- **TermUI** — a Go widget *library*, not a runnable app.
- **IconicFonts** — a patched-font collection, not a runnable app.
- **LearnByExample** — a collection of separate tutorial apps with no single binary.

`gen_catalog.py` gains an `EXCLUDE_APPS` set covering those five, so the weekly report stops re-flagging them, and `BIN_OVERRIDES` learns `flow-control→flow` and `ytreenova→ytnova` so installed-detection matches the real binaries. Verified by regenerating against today's awesome-tuis README: the report now comes up empty except **hexed** (see below).

## Deliberately left out

- **hexed** (Editors, codeberg.org/quorend/hexed) — codeberg.org is unreachable from this environment (network policy), so no install recipe could be derived or verified. It will keep appearing in the weekly report until someone with Codeberg access adds it.

## Gate

- `cargo clippy --all-targets` — 0 warnings
- `cargo test` — 337 passed, 0 failed

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfBaFTHbunVH1ZuhtR7kWu)_