### PR TITLE
docs: document missing config.toml fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ grid_rows = 2
 grid_cols = 3
 tile_gap = 0
 auto_tile = false
-launch_maximized = false  # new windows open maximized (Settings → Windows)
+launch_maximized = false  # true = new windows open maximized (Settings → Windows)
 
 # Working-directory picker (for coding agents flagged requires_cwd)
 default_project_dir = "~/Development"   # picker opens here (default: ~)

--- a/README.md
+++ b/README.md
@@ -218,9 +218,17 @@ grid_rows = 2
 grid_cols = 3
 tile_gap = 0
 auto_tile = false
+launch_maximized = false  # new windows open maximized (Settings → Windows)
 
 # Working-directory picker (for coding agents flagged requires_cwd)
 default_project_dir = "~/Development"   # picker opens here (default: ~)
+
+# Desktop icons (~/Desktop + pins) — no Settings toggle yet, config-only
+desktop_enabled = true
+
+# File-type → app handlers (also editable in Settings → Default Apps)
+[default_apps]
+image = "@image"
 
 # Auto-started at launch (and shown in the dock)
 [[apps]]


### PR DESCRIPTION
## What's stale

Routine docs-freshness audit found three real `Config` fields (`src/config.rs`) that predate this fix but were never added to README's `## Configuration` example block:

- `launch_maximized` — toggled via **Settings → Windows** ("Launch maximized" row, `settings.rs:388`); affects new-window placement.
- `default_apps` — the file-type → app handler map, editable via **Settings → Default Apps** (`settings.rs:267,427`); the feature itself was already documented in "What works today", just not the config key/shape.
- `desktop_enabled` — gates whether desktop icons render (`session.rs`, multiple call sites); no Settings UI row exists for it, so the config example was the only place a user could discover it, and it wasn't there.

## Fix

Added all three to the `toml` example in README.md with brief inline comments, matching the style of neighboring entries. Docs-only change; verified the updated example block still parses as valid TOML.

## Scope check

- No code changes — README.md only.
- No CHANGELOG entry, matching precedent from prior pure docs-freshness fixes (#41, #42).
