### PR TITLE
docs: warn the assistant that tuiui launch skips the CLI-tool wrapper

### DIFF
--- a/agent/DESKTOP.md
+++ b/agent/DESKTOP.md
@@ -4,6 +4,11 @@ These commands talk to the running tuiui daemon (same user, local socket).
 They are how you open windows and arrange the user's desktop.
 
 - `tuiui launch <command> [args…]`   open a new app window running <command>
+  - **CLI tools** (catalog entries tagged `"cli": true` — gum, himalaya, khal,
+    dust, and ~50 others) print usage and exit immediately if launched bare
+    this way; the help-then-shell wrapper only applies inside the launcher
+    menu/Spotlight/Store, not this CLI escape hatch. Launch them as
+    `tuiui launch sh -lc '<bin> --help; exec "$SHELL"'` instead.
 - `tuiui tile`                       tile all windows into the configured grid
 - `tuiui theme <name>`               switch theme (midnight|nord|gruvbox|dracula)
 - `tuiui reload`                     reload the UI (apps keep running)

--- a/agent/DESKTOP.md
+++ b/agent/DESKTOP.md
@@ -8,7 +8,8 @@ They are how you open windows and arrange the user's desktop.
     dust, and ~50 others) print usage and exit immediately if launched bare
     this way; the help-then-shell wrapper only applies inside the launcher
     menu/Spotlight/Store, not this CLI escape hatch. Launch them as
-    `tuiui launch sh -lc '<bin> --help; exec "$SHELL"'` instead.
+    `tuiui launch sh -lc 'gum --help; exec "${SHELL:-sh}"'` instead (substitute
+    the binary name for `gum`).
 - `tuiui tile`                       tile all windows into the configured grid
 - `tuiui theme <name>`               switch theme (midnight|nord|gruvbox|dracula)
 - `tuiui reload`                     reload the UI (apps keep running)


### PR DESCRIPTION
## What's stale

Routine docs-freshness audit found `agent/DESKTOP.md` describing `tuiui launch <command> [args…]` with no caveat about CLI-tagged catalog tools (the ~52 entries with `"cli": true` — gum, himalaya, khal, dust, …).

Traced the code: the help-then-shell wrapper added in commit 2a01eca (`cli_wrap`, `sh -lc '<bin> --help; exec "$SHELL"'`) is only applied by the launcher-menu/Spotlight/Store UI paths (`launch_entry` / `store_activate` in `src/session.rs`). The `ClientMsg::Launch` handler that `tuiui launch` sends (`src/main.rs` → `session.rs::launch`/`launch_in`) spawns the bare command directly and never calls `cli_wrap`. So an assistant-driven `tuiui launch gum` still opens a window that prints usage and exits immediately — the exact bug the CLI-tools feature was built to fix, just reachable through a different launch path.

## Fix

Added a note to `agent/DESKTOP.md` documenting the gap and the workaround: wrap the command in `sh -lc '<bin> --help; exec "$SHELL"'` before passing it to `tuiui launch`.

## Scope check

- No code changes — `agent/DESKTOP.md` only.
- The underlying gap (the `ClientMsg::Launch` path not calling `cli_wrap`) is a real code-level inconsistency, out of scope for a docs-only fix — flagging it separately for a proper fix in `session.rs`.
