### PR TITLE
docs: freshness fixes — dock badge TOML key, desktop_pins example, stale investigation status

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ It's a multiplexer at heart — like tmux, but with windows and a mouse: apps ru
 - **Custom apps** — add your own launcher entries (name + command) from **Settings → Apps**.
 - **Working-directory picker** — launching a coding agent (Claude Code, Aider, …) opens a browsable file-tree so it starts in the project you choose; remembers recent directories. Installing Claude Code also adds a **Claude Code ⚠️** launcher variant running `--dangerously-skip-permissions` — behind a **warning dialog** so it's never launched by accident (your own `[[launcher]]` entries can set a `warn` message too).
 - **Theming** — four built-in palettes (midnight, nord, gruvbox, dracula), switchable live from **Settings → Appearance**.
-- **Dock app-grouping + window rename** — windows of the same app collapse into one dock pill with a colored **letter badge** (per-app color, configurable in `[dock.badges]`); click a grouped pill to choose between its windows. **Right-click a pill** for a context menu (minimise / maximise / close / reset size — Reset re-centres a stranded or mis-sized window at half the work area). **Rename** any window (double-click its titlebar or `Ctrl+Space r`) — the label changes but it stays grouped with its app.
+- **Dock app-grouping + window rename** — windows of the same app collapse into one dock pill with a colored **letter badge** (per-app color, configurable in `[dock_badges]`); click a grouped pill to choose between its windows. **Right-click a pill** for a context menu (minimise / maximise / close / reset size — Reset re-centres a stranded or mis-sized window at half the work area). **Rename** any window (double-click its titlebar or `Ctrl+Space r`) — the label changes but it stays grouped with its app.
 - **Simple view mode** — a top-bar toggle (`⊞` desktop ⇄ `▦` simple) that flips to a tmux-style full-screen-single-app view (no window decorations), keeping the menubar + dock; the dock is your app switcher. Same running apps in both modes.
 - **Persistent daemon + thin client, with live updates** (tmux-style): apps run in a separate **apphost** process and survive client detach, SSH disconnects, **and a frontend reload** — update the binary and **reload the UI without killing your apps** (menubar **Restart**, `tuiui reload`, or **Settings → Update & Reload**). Closing an app window (titlebar **✕**) asks for confirmation first since it ends the process; built-in panels (Store/Settings/Files) close without asking. `tuiui kill` stops everything (daemon + apphost), and works even while a client is attached.
 - **Bare-console mouse (Linux)** — on a raw Linux VT with no GUI terminal, tuiui reads the mouse directly from the **gpm** daemon (`apt install gpm`); see [the gpm section](#mouse-on-a-bare-linux-console-gpm).
@@ -248,7 +248,7 @@ category = "Git"
 # Dock app-badge colors: keyword (matched in the app name/command) → color
 # (a named color or #rrggbb). Unlisted apps get a stable color hashed from
 # their name. The badge is the app's initial; renamed windows keep it.
-[dock.badges]
+[dock_badges]
 claude = "orange"
 kilo = "yellow"
 ```

--- a/README.md
+++ b/README.md
@@ -245,6 +245,15 @@ name = "lazygit"
 command = "lazygit"
 category = "Git"
 
+# Desktop icons pinned alongside your live ~/Desktop files (defaults to
+# Files + Store; no Settings UI yet, hand-edit to add/remove your own).
+[[desktop_pins]]
+name = "Files"
+command = "@files"
+[[desktop_pins]]
+name = "Store"
+command = "@store"
+
 # Dock app-badge colors: keyword (matched in the app name/command) → color
 # (a named color or #rrggbb). Unlisted apps get a stable color hashed from
 # their name. The badge is the app's initial; renamed windows keep it.


### PR DESCRIPTION
## What's stale and what's fixed

**1. Wrong TOML table name for dock badge colors.** README's Configuration example (and the "Dock app-grouping" bullet in "What works today") documented the per-app dock badge colors under a `[dock.badges]` TOML table. `Config::dock_badges` (`src/config.rs:117`) has no `#[serde(rename)]`, so the real TOML key is `dock_badges`, not a dotted `[dock.badges]` table. Verified by round-tripping both forms through `Config::from_toml_str`:
- `[dock.badges]` with custom entries deserializes to the *defaults* — any custom colors are silently dropped.
- `[dock_badges]` deserializes correctly, including custom entries.

This bug survived prior docs-freshness passes because the example's own values (`claude = "orange"`, `kilo = "yellow"`) are identical to the built-in defaults, masking the drop.

**2. `desktop_pins` had no documented TOML example.** The Configuration section had worked examples for `[[apps]]` and `[[launcher]]` but none for `desktop_pins`, even though "What works today" documents pinned desktop shortcuts as a user-facing feature and `Config::desktop_pins` (`src/config.rs:92-95`) is an actively-used `AppEntry` list, not internal-only. Added an example matching the real `default_desktop_pins()` entries (Files + Store via `@files`/`@store`).

**3. Stale "open investigation" status contradicting CLAUDE.md.** `docs/superpowers/plans/2026-06-14-update-stuck-investigation.md` still read as an open bug "blocked on a log from the user." Commit `1ef7c35` (shipped as 0.2.10) root-caused and fixed it — both `install.sh` and `check_for_updates()` were hitting GitHub's rate-limited REST API for the latest-release lookup, which silently fell back to a slow source build once rate-limited. Commit `31846f9` updated CLAUDE.md to say so, but never touched this plans doc, leaving the two docs contradicting each other. Added a short "Resolved in 0.2.10" note at the top, per this repo's append-only convention for dated plan docs (kept the original historical body intact below it).

**4. README install line omitted Linux arm64.** The "Prebuilt binary" line under Install said "macOS arm64/x86_64, Linux x86_64" — but the release build matrix (`.github/workflows/release.yml`) has built an `aarch64-unknown-linux-gnu` binary on the `ubuntu-22.04-arm` runner (one of the four platform targets CLAUDE.md itself already describes correctly), and `install.sh` maps `Linux/aarch64` to that target. The one platform-support line a user actually reads was simply incomplete. Now reads "Linux x86_64/arm64".

## Scope check

- Docs-only — `README.md` and one file under `docs/superpowers/plans/` — no code/config/CI changes.
- Left the rest of `docs/superpowers/{specs,plans}/*.md` untouched — those are historical design records per the repo's append-only convention.

## Repo activity (informational, no action taken)

- No new issues/PRs/CI failures in the last ~6 hours as of this update (2026-08-05); no commits to main since 2026-08-03; last CI runs (Release, Catalog check) both green.
- Issue #34 (Wayland compositor tracking) remains open and unchanged.
- Issue #49 (catalog-update) remains open; a fresh catalog check today found the same 5 outstanding candidates already listed on the issue (bullmq-dash, gitwig, sabiql, fyzenor, marchat) — nothing new to add.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Corrected the README configuration table name to `dock_badges`.
  * Added default desktop pin examples for Files and Store.
  * Documented prebuilt Linux arm64 binaries alongside supported platforms.
  * Added guidance for Hermes-specific assistant arguments.
  * Added an investigation update confirming the stuck updater issue was resolved in version `0.2.10`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->